### PR TITLE
fix: rename also tar.gz file

### DIFF
--- a/codegen/rename_whl.py
+++ b/codegen/rename_whl.py
@@ -13,6 +13,6 @@ for name in glob.glob("dist/*.whl"):
 for name in glob.glob("dist/*.tar.gz"):
     chunks = name.split(".")
     if len(chunks) == 5:
-        chunks.insert(2, f"-{date_tag}")
+        chunks[2] = f"{chunks[2]}-{date_tag}"
         new_name = ".".join(chunks)
         os.rename(name, new_name)


### PR DESCRIPTION
Following https://github.com/ansys/pydynamicreporting/actions/runs/5418878056/jobs/9851418468

Issue is that though the wheel is renamed, the tar.gz file isn't. And when trying to upload it, it fails. Also renaming tar.gz file now