### PR TITLE
Fix import for downloading pdf from UI. 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,7 @@ features. This is the best place to post questions and code.
 Installation
 ------------
 The ``pydynamicreporting`` package supports Python 3.7 through 3.11 on
-Windows and Linux. It is currently available on the PyPi 
+Windows and Linux. It is currently available on the PyPi
 `repository <https://pypi.org/project/ansys-dynamicreporting-core/>`_.
 
 To install the package, simply run
@@ -65,7 +65,7 @@ To install the package, simply run
    pip install ansys-dynamicreporting-core
 
 
-Alternatively, the user can download the repository and locally build the 
+Alternatively, the user can download the repository and locally build the
 package. Two modes of installation are available:
 
 - Developer installation

--- a/README.rst
+++ b/README.rst
@@ -55,24 +55,18 @@ features. This is the best place to post questions and code.
 Installation
 ------------
 The ``pydynamicreporting`` package supports Python 3.7 through 3.11 on
-Windows and Linux. It is currently available only on the Ansys private
-repository at `PyAnsysPyPI <https://pkgs.dev.azure.com/pyansys/_packaging/pyansys/pypi>`_.
+Windows and Linux. It is currently available on the PyPi 
+`repository <https://pypi.org/project/ansys-dynamicreporting-core/>`_.
 
-Installing from this private repository requires a PAT (private access
-token). For information on obtaining a PAT, see `Release and publishing
-<https://dev.docs.pyansys.com/dev/how-to/releasing.html#downloading-artifacts>`_
-in the *PyAnsys Developer's Guide*.
-
-To install the package from the Ansys private repository, run this code,
-where ``<PAT>`` is the obtained token:
+To install the package, simply run
 
 .. code::
 
-   pip install --pre ansys-dynamicreporting-core --index-url=https://<PAT>@pkgs.dev.azure.com/pyansys/_packaging/pyansys/pypi/simple/
+   pip install ansys-dynamicreporting-core
 
 
-Once the ``pydynamicreporting`` package is publicly available on GitHub, two modes
-of installation are available:
+Alternatively, the user can download the repository and locally build the 
+package. Two modes of installation are available:
 
 - Developer installation
 - User installation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires = [
 
 [project]
 name = "ansys-dynamicreporting-core"
-version = "0.4.dev0"
+version = "0.5.dev0"
 authors = [
     {name = "ANSYS, Inc.", email = "pyansys.core@ansys.com"},
 ]

--- a/src/ansys/dynamicreporting/core/utils/report_remote_server.py
+++ b/src/ansys/dynamicreporting/core/utils/report_remote_server.py
@@ -865,7 +865,7 @@ class Server:
         url = self.build_url_with_query(report_guid, query)
         file_path = os.path.abspath(file_name)
         if has_qt and (parent is not None):
-            from report_download_pdf import NexusPDFSave
+            from .report_download_pdf import NexusPDFSave
 
             app = QtGui.QGuiApplication.instance()
             worker = NexusPDFSave(app)


### PR DESCRIPTION
Fix relative imports
Fix docs to refer to official PyPi for installation instead of ansys-only
Bump version