### PR TITLE
Fix/add dev environment

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -107,7 +107,6 @@ numpydoc_validation_checks = {
 
 # -- Sphinx Gallery Options
 examples_source = os.path.join(os.path.dirname(__file__), "examples_source")
-default_thumb = os.path.join(os.path.dirname(__file__), "_static", "default_thumb.png")
 
 sphinx_gallery_conf = {
     # convert rst to md for ipynb
@@ -126,7 +125,6 @@ sphinx_gallery_conf = {
     "backreferences_dir": None,
     # the initial notebook cell
     "first_notebook_cell": ("# ``pydynamicreporting`` example Notebook\n" "#\n"),
-    "default_thumb_file": default_thumb,
     "plot_gallery": False,
 }
 

--- a/doc/source/examples_source/00-basic/00-create_db.py
+++ b/doc/source/examples_source/00-basic/00-create_db.py
@@ -125,4 +125,5 @@ my_tree.visualize()
 # Close the Ansys Dynamic Reporting service. The database with the items that
 # were created remains on disk.
 
+# sphinx_gallery_thumbnail_path = '_static/00_create_db_0.png'
 adr_service.stop()

--- a/doc/source/examples_source/00-basic/01-connect.py
+++ b/doc/source/examples_source/00-basic/01-connect.py
@@ -101,4 +101,5 @@ adr_service.visualize_report(filter=f"A|s_guid|cont|{connected_s.session_guid}")
 # Close the Ansys Dynamic Reporting service. The database with the items that
 # were created remains on disk.
 
+# sphinx_gallery_thumbnail_path = '_static/01_connect_3.png'
 adr_service.stop()

--- a/doc/source/examples_source/00-basic/01-connect.py
+++ b/doc/source/examples_source/00-basic/01-connect.py
@@ -5,7 +5,7 @@ Connect services
 ================
 
 This example shows how to start an Ansys Dynamic Reporting
-service via a DOcker image, create a second instance of the ``Service``
+service via a Docker image, create a second instance of the ``Service``
 class, and connect it to the already running service. It then shows
 how to create and modify items in the original database with this
 new instance.

--- a/doc/source/examples_source/25-intermediate/00-tagging.py
+++ b/doc/source/examples_source/25-intermediate/00-tagging.py
@@ -80,4 +80,5 @@ dp3_items = adr_service.query(filter="A|i_tags|cont|dp=3")
 # Close the Ansys Dynamic Reporting service. The database with the items that
 # were created remains on disk.
 
+# sphinx_gallery_thumbnail_path = '_static/default_thumb.png'
 adr_service.stop()

--- a/doc/source/examples_source/25-intermediate/01-queries.py
+++ b/doc/source/examples_source/25-intermediate/01-queries.py
@@ -89,4 +89,5 @@ test_five = len(dp0_items) == len(dp10_items) == len(dp33_items) == 2
 # Close the Ansys Dynamic Reporting service. The database with the items that
 # were created remains on disk.
 
+# sphinx_gallery_thumbnail_path = '_static/default_thumb.png'
 adr_service.stop()

--- a/doc/source/examples_source/50-advanced/00-complete_report.py
+++ b/doc/source/examples_source/50-advanced/00-complete_report.py
@@ -362,4 +362,5 @@ adr_service.visualize_report(report_name="Solution Analysis from Multiphysics si
 # Close the Ansys Dynamic Reporting service. The database with the items that
 # were created remains on disk.
 
+# sphinx_gallery_thumbnail_path = '_static/00_complete_report_0.png'
 adr_service.stop()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,7 @@ markers =[
     "integration:Run integration tests",
     "smoke:Run the smoke tests",
     "unit:Run the unit tests",
+    "ado_test: subset of tests to be run in the ADO pipeline for ADR",
 ]
 norecursedirs =[
   ".git",

--- a/src/ansys/dynamicreporting/core/adr_service.py
+++ b/src/ansys/dynamicreporting/core/adr_service.py
@@ -210,14 +210,25 @@ class Service:
                 self._ansys_installation = ansys_installation
                 # verify new path
                 if not os.path.isdir(ansys_installation):
-                    raise InvalidAnsysPath(ansys_installation)
+                    # Option for local development build
+                    if os.environ.get("CEIDEVROOTDOS") is not None:
+                        self._ansys_installation = os.environ.get("CEIDEVROOTDOS")
+                    else:
+                        raise InvalidAnsysPath(ansys_installation)
             if self._ansys_version is None:
                 # try to get version from install path
-                matches = re.search(r".*v([0-9]{3}).*", ansys_installation)
-                try:
-                    self._ansys_version = int(matches.group(1))
-                except IndexError:
-                    raise AnsysVersionAbsentError
+                matches = re.search(r".*v([0-9]{3}).*", self._ansys_installation)
+                if matches is None:
+                    # Option for local development build
+                    if os.environ.get("ANSYS_REL_INT_I") is not None:
+                        self._ansys_version = int(os.environ.get("ANSYS_REL_INT_I"))
+                    else:
+                        raise AnsysVersionAbsentError
+                else:
+                    try:
+                        self._ansys_version = int(matches.group(1))
+                    except IndexError:
+                        raise AnsysVersionAbsentError
 
     @property
     def session_guid(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,7 +78,10 @@ def adr_service_query(request, pytestconfig: pytest.Config) -> Service:
     else:
         cleanup_docker(request)
         ansys_installation = "docker"
-    subprocess.run(["git", "restore", db_dir])
+    try:
+        subprocess.run(["git", "restore", db_dir])
+    except:
+        pass
     tmp_service = Service(
         ansys_installation=ansys_installation,
         docker_image=DOCKER_DEV_REPO_URL,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,6 +78,7 @@ def adr_service_query(request, pytestconfig: pytest.Config) -> Service:
     else:
         cleanup_docker(request)
         ansys_installation = "docker"
+    subprocess.run(["git", "restore", db_dir])
     tmp_service = Service(
         ansys_installation=ansys_installation,
         docker_image=DOCKER_DEV_REPO_URL,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,16 +72,13 @@ def adr_service_create(request, pytestconfig: pytest.Config) -> Service:
 @pytest.fixture
 def adr_service_query(request, pytestconfig: pytest.Config) -> Service:
     use_local = pytestconfig.getoption("use_local_launcher")
-    db_dir = os.path.join(os.path.join(request.fspath.dirname, "test_data"), "query_db")
+    local_db = os.path.join("test_data", "query_db")
+    db_dir = os.path.join(request.fspath.dirname, local_db)
     if use_local:
         ansys_installation = pytestconfig.getoption("install_path")
     else:
         cleanup_docker(request)
         ansys_installation = "docker"
-    try:
-        subprocess.run(["git", "restore", db_dir])
-    except:
-        pass
     tmp_service = Service(
         ansys_installation=ansys_installation,
         docker_image=DOCKER_DEV_REPO_URL,

--- a/tests/test_encoders.py
+++ b/tests/test_encoders.py
@@ -1,4 +1,5 @@
 import datetime
+import pytest
 import uuid
 
 import numpy as np
@@ -7,34 +8,40 @@ from ansys.dynamicreporting.core.utils import encoders as en
 from ansys.dynamicreporting.core.utils import report_utils as ru
 
 
+@pytest.mark.ado_test
 def test_payload() -> bool:
     b = en.PayloaddataEncoder()
     res = b.default(obj=ru.nexus_array())
     assert res == [[0.0]]
 
 
+@pytest.mark.ado_test
 def test_base_datetime() -> bool:
     a = en.BaseEncoder()
     assert a.default(obj=datetime.datetime(year=2023, month=4, day=10)) == "2023-04-10T00:00:00"
 
 
+@pytest.mark.ado_test
 def test_uuid() -> bool:
     a = en.PayloaddataEncoder()
     assert type(a.default(obj=uuid.uuid1())) is str
 
 
+@pytest.mark.ado_test
 def test_bytes() -> bool:
     a = en.BaseEncoder()
     mystr = "aa"
     assert a.default(obj=mystr.encode()) == mystr
 
 
+@pytest.mark.ado_test
 def test_dict() -> bool:
     a = en.BaseEncoder()
     mydict = {"a": 1}
     assert a.default(obj=mydict) == mydict
 
 
+@pytest.mark.ado_test
 def test_nparray() -> bool:
     a = en.PayloaddataEncoder()
     assert isinstance(a.default(obj=np.ndarray(shape=(1, 1))), list)

--- a/tests/test_filelock.py
+++ b/tests/test_filelock.py
@@ -1,6 +1,7 @@
 import os
 from os.path import join
 import platform
+import pytest
 
 try:
     import msvcrt
@@ -16,6 +17,7 @@ from ansys.dynamicreporting.core.utils import filelock as fl
 open_mode = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_TRUNC
 
 
+@pytest.mark.ado_test
 def test_timeout(request) -> bool:
     test_path = join(request.fspath.dirname, "test_data")
     tmp_file = join(test_path, "time.txt")
@@ -24,6 +26,7 @@ def test_timeout(request) -> bool:
     assert "could not be acquired" in a.__str__()
 
 
+@pytest.mark.ado_test
 def test_base_acquire(request) -> bool:
     test_path = join(request.fspath.dirname, "test_data")
     tmp_file = join(test_path, "base.txt")
@@ -38,6 +41,7 @@ def test_base_acquire(request) -> bool:
     assert success
 
 
+@pytest.mark.ado_test
 def test_base_release(request) -> bool:
     test_path = join(request.fspath.dirname, "test_data")
     tmp_file = join(test_path, "base2.txt")
@@ -52,6 +56,7 @@ def test_base_release(request) -> bool:
     assert success
 
 
+@pytest.mark.ado_test
 def test_base_locked(request) -> bool:
     test_path = join(request.fspath.dirname, "test_data")
     tmp_file = join(test_path, "base3.txt")
@@ -60,6 +65,7 @@ def test_base_locked(request) -> bool:
     assert a.is_locked is False
 
 
+@pytest.mark.ado_test
 def test_base_rel(request) -> bool:
     test_path = join(request.fspath.dirname, "test_data")
     tmp_file = join(test_path, "base4.txt")
@@ -68,6 +74,7 @@ def test_base_rel(request) -> bool:
     assert a.release() is None
 
 
+@pytest.mark.ado_test
 def test_platform_lock(request) -> bool:
     test_path = join(request.fspath.dirname, "test_data")
     tmp_file = join(test_path, "platform.txt")
@@ -87,6 +94,7 @@ def test_platform_lock(request) -> bool:
     assert one is None and two is None
 
 
+@pytest.mark.ado_test
 def test_soft(request) -> bool:
     test_path = join(request.fspath.dirname, "test_data")
     tmp_file = join(test_path, "soft.txt")

--- a/tests/test_geofile_processing.py
+++ b/tests/test_geofile_processing.py
@@ -1,4 +1,5 @@
 from os.path import isdir, join
+import pytest
 
 from ansys.dynamicreporting.core.utils import geofile_processing as gp
 
@@ -15,6 +16,7 @@ def return_file_paths(request):
     return [image_file, scene_file, ens_file, evsn_file, scdoc_file, csf_file, img_proxy]
 
 
+@pytest.mark.ado_test
 def test_get_evsn_proxy_image(request) -> bool:
     try:
         _ = gp.get_evsn_proxy_image(filename=return_file_paths(request)[6])
@@ -24,23 +26,27 @@ def test_get_evsn_proxy_image(request) -> bool:
     assert (_ is None) and success
 
 
+@pytest.mark.ado_test
 def test_get_evsn_proxy_error(request) -> bool:
     succ = gp.get_evsn_proxy_image(filename=return_file_paths(request)[5]) is None
     assert succ
 
 
+@pytest.mark.ado_test
 def test_file_can_have_proxy(request) -> bool:
     scene = gp.file_can_have_proxy(return_file_paths(request)[1])
     img = gp.file_can_have_proxy(return_file_paths(request)[0])
     assert scene is True and img is False
 
 
+@pytest.mark.ado_test
 def test_file_is_3d_geometry(request) -> bool:
     scene = gp.file_is_3d_geometry(return_file_paths(request)[1], file_item_only=False)
     img = gp.file_is_3d_geometry(return_file_paths(request)[0])
     assert scene is True and img is False
 
 
+@pytest.mark.ado_test
 def test_rebuild_3d_geom_avz(request) -> bool:
     _ = gp.rebuild_3d_geometry(
         csf_file=return_file_paths(request)[1], unique_id="abc", exec_basis="avz"
@@ -50,6 +56,7 @@ def test_rebuild_3d_geom_avz(request) -> bool:
     assert isdir(new_dir)
 
 
+@pytest.mark.ado_test
 def test_rebuild_3d_geom_ens(request) -> bool:
     _ = gp.rebuild_3d_geometry(
         csf_file=return_file_paths(request)[2], unique_id="abc", exec_basis="avz"
@@ -59,6 +66,7 @@ def test_rebuild_3d_geom_ens(request) -> bool:
     assert isdir(new_dir)
 
 
+@pytest.mark.ado_test
 def test_rebuild_3d_geom_evsn(request) -> bool:
     _ = gp.rebuild_3d_geometry(
         csf_file=return_file_paths(request)[3], unique_id="abc", exec_basis="avz"
@@ -68,6 +76,7 @@ def test_rebuild_3d_geom_evsn(request) -> bool:
     assert isdir(new_dir)
 
 
+@pytest.mark.ado_test
 def test_rebuild_3d_geom_scdoc(request) -> bool:
     _ = gp.rebuild_3d_geometry(
         csf_file=return_file_paths(request)[4], unique_id="abc", exec_basis="avz"

--- a/tests/test_hacks.py
+++ b/tests/test_hacks.py
@@ -1,29 +1,36 @@
 import pickle
+import pytest
 import uuid
 
 from ansys.dynamicreporting.core.utils import extremely_ugly_hacks as ex
 
 
+@pytest.mark.ado_test
 def test_unpicke() -> bool:
     assert ex.safe_unpickle(input_data="!@P{}", item_type="tree") == "!@P{}"
 
 
+@pytest.mark.ado_test
 def test_unpickle_empty() -> bool:
     assert ex.safe_unpickle(input_data="") == ""
 
 
+@pytest.mark.ado_test
 def test_unpickle_bytes() -> bool:
     assert ex.safe_unpickle(input_data=pickle.dumps("!@P{}")) == "!@P{}"
 
 
+@pytest.mark.ado_test
 def test_unpickle_none() -> bool:
     assert ex.safe_unpickle(input_data=None) is None
 
 
+@pytest.mark.ado_test
 def test_unpickle_nobeg() -> bool:
     assert ex.safe_unpickle(input_data=pickle.dumps("abcde")) == "abcde"
 
 
+@pytest.mark.ado_test
 def test_unpickle_error() -> bool:
     success = False
     try:
@@ -33,6 +40,7 @@ def test_unpickle_error() -> bool:
     assert success
 
 
+@pytest.mark.ado_test
 def test_rec_tree() -> bool:
     test = ex.reconstruct_tree_item(
         [{b"a": 1}, {1: b"b"}, {1: uuid.uuid1()}, {1: [{"a": "b"}, {}]}]
@@ -40,6 +48,7 @@ def test_rec_tree() -> bool:
     assert len(test) == 4
 
 
+@pytest.mark.ado_test
 def test_rec_int_data() -> bool:
     test = ex.reconstruct_international_text(data={"a": [1, 2, 3], "b": 2})
     assert test == {"a": [1, 2, 3], "b": 2}

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -1,10 +1,12 @@
 from os.path import join
 
 import numpy as np
+import pytest
 
 from ansys.dynamicreporting.core import Item, Service
 
 
+@pytest.mark.ado_test
 def test_create_img(adr_service_create, request) -> bool:
     _ = adr_service_create.start(
         create_db=True,
@@ -167,6 +169,7 @@ def test_iframe_on_img_item(adr_service_query) -> bool:
     assert success is True
 
 
+@pytest.mark.ado_test
 def test_get_url(adr_service_query) -> bool:
     filter_str = "A|i_type|cont|table"
     one_item = adr_service_query.query(query_type="Item", filter=filter_str)
@@ -175,6 +178,7 @@ def test_get_url(adr_service_query) -> bool:
     assert (url is not None) and ("http" in url)
 
 
+@pytest.mark.ado_test
 def test_create_table(adr_service_create) -> bool:
     _ = adr_service_create.start(
         create_db=True,
@@ -268,6 +272,7 @@ def test_get_tags(adr_service_query) -> bool:
     assert success is True and len(tags) == 36
 
 
+@pytest.mark.ado_test
 def test_add_tag(adr_service_query) -> bool:
     success = False
     try:

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -33,7 +33,6 @@ def test_iframe_report(adr_service_query) -> bool:
     except SyntaxError:
         success = False
     adr_service_query.stop()
-
     assert success is True
 
 

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,4 +1,5 @@
 import os
+import pytest
 
 from ansys.dynamicreporting.core import Report, Service
 from ansys.dynamicreporting.core.utils import report_remote_server
@@ -11,6 +12,7 @@ def test_geturl_report(adr_service_query) -> bool:
     assert "http:" in url
 
 
+@pytest.mark.ado_test
 def test_visualize_report(adr_service_query) -> bool:
     success = False
     try:
@@ -36,6 +38,7 @@ def test_iframe_report(adr_service_query) -> bool:
     assert success is True
 
 
+@pytest.mark.ado_test
 def test_unit_report_url(request) -> bool:
     logfile = os.path.join(request.fspath.dirname, "outfile_3.txt")
     a = Service(logfile=logfile)
@@ -50,6 +53,7 @@ def test_unit_report_url(request) -> bool:
     assert err_msg
 
 
+@pytest.mark.ado_test
 def test_unit_report_visualize(request) -> bool:
     logfile = os.path.join(request.fspath.dirname, "outfile_6.txt")
     a = Service(logfile=logfile)
@@ -64,6 +68,7 @@ def test_unit_report_visualize(request) -> bool:
     assert err_msg
 
 
+@pytest.mark.ado_test
 def test_unit_report_iframe(request) -> bool:
     logfile = os.path.join(request.fspath.dirname, "outfile_6.txt")
     a = Service(logfile=logfile)
@@ -78,6 +83,7 @@ def test_unit_report_iframe(request) -> bool:
     assert err_msg
 
 
+@pytest.mark.ado_test
 def test_unit_no_url(request) -> bool:
     logfile = os.path.join(request.fspath.dirname, "outfile_6.txt")
     a = Service(logfile=logfile)

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -5,6 +5,7 @@ from ansys.dynamicreporting.core import Report, Service
 from ansys.dynamicreporting.core.utils import report_remote_server
 
 
+@pytest.mark.ado_test
 def test_geturl_report(adr_service_query) -> bool:
     my_report = adr_service_query.get_report(report_name="My Top Report")
     url = my_report.get_url()
@@ -12,7 +13,6 @@ def test_geturl_report(adr_service_query) -> bool:
     assert "http:" in url
 
 
-@pytest.mark.ado_test
 def test_visualize_report(adr_service_query) -> bool:
     success = False
     try:
@@ -53,7 +53,6 @@ def test_unit_report_url(request) -> bool:
     assert err_msg
 
 
-@pytest.mark.ado_test
 def test_unit_report_visualize(request) -> bool:
     logfile = os.path.join(request.fspath.dirname, "outfile_6.txt")
     a = Service(logfile=logfile)

--- a/tests/test_report_objects.py
+++ b/tests/test_report_objects.py
@@ -1,14 +1,17 @@
 import datetime
 import json
+import pytest
 import uuid
 
 from ansys.dynamicreporting.core.utils import report_objects as ro
 
 
+@pytest.mark.ado_test
 def test_convert_color() -> bool:
     assert ro.convert_color([1, 2, 3]) == "#ff1fe2fd"
 
 
+@pytest.mark.ado_test
 def test_convert_syle() -> bool:
     one = ro.convert_style(1, 0) == "none"
     two = ro.convert_style(1, 1) == "dot"
@@ -16,6 +19,7 @@ def test_convert_syle() -> bool:
     assert one and two and three
 
 
+@pytest.mark.ado_test
 def test_convert_marker() -> bool:
     one = ro.convert_marker(1) == "circle"
     two = ro.convert_marker(2) == "circle-open"
@@ -25,6 +29,7 @@ def test_convert_marker() -> bool:
     assert one and two and three and four and five
 
 
+@pytest.mark.ado_test
 def test_convert_label_format() -> bool:
     one = ro.convert_label_format("aaaf") == "floatdota"
     two = ro.convert_label_format("aaa") == "scientific"
@@ -32,10 +37,12 @@ def test_convert_label_format() -> bool:
     assert one and two and three
 
 
+@pytest.mark.ado_test
 def test_title_units() -> bool:
     assert ro.get_title_units("a", "v") == "a"
 
 
+@pytest.mark.ado_test
 class e_query:
     def __init__(self, norx=False, nory=False):
         self.QUERY_DATA = {
@@ -59,6 +66,7 @@ class e_query:
         self.RGB = [1.0, 0.0, 0.0]
 
 
+@pytest.mark.ado_test
 class e_plotter:
     def __init__(self):
         self.QUERIES = [e_query(), e_query(norx=True, nory=True)]
@@ -79,31 +87,37 @@ class e_plotter:
         self.AXISXLABELFORMAT = "%g"
 
 
+@pytest.mark.ado_test
 def test_extract_data_query() -> bool:
     a = e_query()
     assert (ro.extract_data_from_ensight_query(a) == [[0, 1], [0, 3]]).all()
 
 
+@pytest.mark.ado_test
 def test_extract_data_query_norm() -> bool:
     a = e_query(norx=True, nory=True)
     assert (ro.extract_data_from_ensight_query(a) == [[0, 1], [0, 1]]).all()
 
 
+@pytest.mark.ado_test
 def test_extract_data_plotter() -> bool:
     a = e_plotter()
     assert isinstance(ro.map_ensight_plot_to_table_dictionary(a), dict)
 
 
+@pytest.mark.ado_test
 def test_split_quoted() -> bool:
     assert ro.split_quoted_string_list(s="aa,aa", deliminator=",") == ["aa", "aa"]
 
 
+@pytest.mark.ado_test
 def test_query_parse() -> bool:
     one = ro.parse_filter(query="A|i_name|eq|test;")
     two = ro.parse_filter(query=b"A|i_name|eq|test;")
     assert len(one) == len(two) == 1
 
 
+@pytest.mark.ado_test
 def test_template() -> bool:
     a = ro.Template(initial_data={"a": 1}, mar="test")
     a.paste_reset()
@@ -114,6 +128,7 @@ def test_template() -> bool:
     assert params == mydict
 
 
+@pytest.mark.ado_test
 def test_template_types() -> bool:
     a = ro.Template(initial_data={"a": 1}, mar="test")
     one = a.report_type
@@ -121,6 +136,7 @@ def test_template_types() -> bool:
     assert one == "Layout:basic"
 
 
+@pytest.mark.ado_test
 def test_template_dirty() -> bool:
     a = ro.Template(initial_data={"a": 1}, mar="test")
     _ = a.from_json(json_dict={"a": 3})
@@ -128,16 +144,19 @@ def test_template_dirty() -> bool:
     assert a.get_dirty()
 
 
+@pytest.mark.ado_test
 def test_template_date() -> bool:
     a = ro.Template(initial_data={"a": 1}, mar="test")
     assert type(a.get_date_object()) is datetime.datetime
 
 
+@pytest.mark.ado_test
 def test_template_get() -> bool:
     a = ro.Template(initial_data={"a": 1}, mar="test")
     assert len(a.get_url_data()) == 2 and a.get_url_file() is None
 
 
+@pytest.mark.ado_test
 def test_tempalte_child() -> bool:
     a = ro.Template(initial_data={"a": 1}, mar="test")
     b = ro.Template()
@@ -145,6 +164,7 @@ def test_tempalte_child() -> bool:
     assert a.get_child_objects() == []
 
 
+@pytest.mark.ado_test
 def test_baserest() -> bool:
     a = ro.BaseRESTObject()
     a.generate_new_guid()
@@ -160,6 +180,7 @@ def test_baserest() -> bool:
     )
 
 
+@pytest.mark.ado_test
 def test_itemcategory() -> bool:
     a = ro.ItemCategoryREST()
     item = a.get_url_base_name()
@@ -170,12 +191,14 @@ def test_itemcategory() -> bool:
     )
 
 
+@pytest.mark.ado_test
 def test_itemcategory_dict() -> bool:
     a = ro.ItemCategoryREST()
     mydict = a.get_json_key_limits()
     assert mydict == {"name": 80}
 
 
+@pytest.mark.ado_test
 def test_itemcategory_url() -> bool:
     a = ro.ItemCategoryREST()
     success = False
@@ -186,6 +209,7 @@ def test_itemcategory_url() -> bool:
     assert success
 
 
+@pytest.mark.ado_test
 def test_category() -> bool:
     a = ro.ItemREST()
     one = a._validate_and_get_category(category="test")
@@ -212,6 +236,7 @@ def test_category() -> bool:
     assert one == "test" and two == "" and a.is_file_protocol() is False and succ_a
 
 
+@pytest.mark.ado_test
 def test_factory() -> bool:
     a = ro.TemplateREST()
     assert isinstance(
@@ -219,6 +244,7 @@ def test_factory() -> bool:
     ) and isinstance(a.factory(json_data={}), ro.TemplateREST)
 
 
+@pytest.mark.ado_test
 def test_templaterest() -> bool:
     a = ro.TemplateREST()
     a.reorder_children()
@@ -227,6 +253,7 @@ def test_templaterest() -> bool:
     assert len(a.get_url_data()) == 2
 
 
+@pytest.mark.ado_test
 def test_templaterest_params() -> bool:
     a = ro.TemplateREST()
     a.add_params()
@@ -245,6 +272,7 @@ def test_templaterest_params() -> bool:
     assert a.get_params() == {"b": 2, "a": 1} and succ and succ_two
 
 
+@pytest.mark.ado_test
 def test_templaterest_sort() -> bool:
     a = ro.TemplateREST()
     succ = a.get_sort_fields() == []
@@ -262,6 +290,7 @@ def test_templaterest_sort() -> bool:
     assert succ and succ_three and succ_four and succ_five
 
 
+@pytest.mark.ado_test
 def test_templaterest_fields() -> bool:
     a = ro.TemplateREST()
     succ_three = a.get_sort_selection() == ""
@@ -292,6 +321,7 @@ def test_templaterest_fields() -> bool:
     assert succ_a and succ_four and succ_five
 
 
+@pytest.mark.ado_test
 def test_templaterest_filter() -> bool:
     a = ro.TemplateREST()
     strone = "firstfilter"
@@ -326,6 +356,7 @@ def test_templaterest_filter() -> bool:
     assert succ_a and succ and succ_two and succ_three and succ_four and succ_five
 
 
+@pytest.mark.ado_test
 def test_layout_col() -> bool:
     a = ro.LayoutREST()
     one = a.get_column_count()
@@ -343,6 +374,7 @@ def test_layout_col() -> bool:
     assert one == 1 and success and success_two
 
 
+@pytest.mark.ado_test
 def test_layout_col_width() -> bool:
     a = ro.LayoutREST()
     one = a.get_column_widths()
@@ -355,6 +387,7 @@ def test_layout_col_width() -> bool:
     assert one == [1.0] and success and a.get_column_widths() == [1, 2]
 
 
+@pytest.mark.ado_test
 def test_layout_html() -> bool:
     a = ro.LayoutREST()
     a.set_html(value="onetwo")
@@ -366,6 +399,7 @@ def test_layout_html() -> bool:
     assert success
 
 
+@pytest.mark.ado_test
 def test_set_comments() -> None:
     a = ro.LayoutREST()
     a.set_comments(value="lololol")
@@ -377,6 +411,7 @@ def test_set_comments() -> None:
     assert success
 
 
+@pytest.mark.ado_test
 def test_layout_transport() -> bool:
     a = ro.LayoutREST()
     zero = a.get_transpose()
@@ -396,6 +431,7 @@ def test_layout_transport() -> bool:
     assert 0 == zero and success and successtwo and res == "aa"
 
 
+@pytest.mark.ado_test
 def test_layout_skip() -> bool:
     a = ro.LayoutREST()
     zero = a.get_skip()
@@ -414,6 +450,7 @@ def test_layout_skip() -> bool:
     assert zero == 0 and success and successtwo and one == 1
 
 
+@pytest.mark.ado_test
 def test_gen() -> bool:
     a = ro.GeneratorREST()
     add = a.get_generated_items() == "add"
@@ -432,6 +469,7 @@ def test_gen() -> bool:
     assert add and success and successtwo and addtwo
 
 
+@pytest.mark.ado_test
 def test_gen_tags() -> bool:
     a = ro.GeneratorREST()
     one = a.get_append_tags()
@@ -444,11 +482,13 @@ def test_gen_tags() -> bool:
     assert one and success
 
 
+@pytest.mark.ado_test
 def test_basic() -> bool:
     _ = ro.basicREST()
     assert True
 
 
+@pytest.mark.ado_test
 def test_panel() -> bool:
     a = ro.panelREST()
     one = a.get_panel_style() == ""
@@ -462,6 +502,7 @@ def test_panel() -> bool:
     assert one and success and two
 
 
+@pytest.mark.ado_test
 def test_panel_link() -> bool:
     a = ro.panelREST()
     one = a.get_items_as_link() == 0
@@ -480,6 +521,7 @@ def test_panel_link() -> bool:
     assert one and success and successtwo and two
 
 
+@pytest.mark.ado_test
 def test_box() -> bool:
     a = ro.boxREST()
     one = a.get_children_layout() == {}
@@ -521,11 +563,13 @@ def test_box() -> bool:
     assert one and succ_a and succ_b
 
 
+@pytest.mark.ado_test
 def test_tabs() -> bool:
     _ = ro.tabsREST()
     assert True
 
 
+@pytest.mark.ado_test
 def test_carosel() -> bool:
     a = ro.carouselREST()
     one = a.get_animated() == 0
@@ -539,6 +583,7 @@ def test_carosel() -> bool:
     assert one and success and two
 
 
+@pytest.mark.ado_test
 def test_carosel_dot() -> bool:
     a = ro.carouselREST()
     one = a.get_slide_dots() == 20
@@ -552,6 +597,7 @@ def test_carosel_dot() -> bool:
     assert one and success and two
 
 
+@pytest.mark.ado_test
 def test_slider() -> bool:
     a = ro.sliderREST()
     succ = a.get_map_to_slider() == []
@@ -577,6 +623,7 @@ def test_slider() -> bool:
     assert succ and succ_two and succ_three and succ_four and succ_five
 
 
+@pytest.mark.ado_test
 def test_foot_head() -> bool:
     _ = ro.footerREST()
     _ = ro.headerREST()
@@ -584,6 +631,7 @@ def test_foot_head() -> bool:
     assert True
 
 
+@pytest.mark.ado_test
 def test_iterator() -> bool:
     a = ro.iteratorREST()
     succ = a.get_iteration_tags() == ["", ""]
@@ -635,6 +683,7 @@ def test_iterator() -> bool:
     assert succ_a and succ_b and succ_c
 
 
+@pytest.mark.ado_test
 def test_toc() -> bool:
     a = ro.tocREST()
     succ = a.get_toc() is None
@@ -652,6 +701,7 @@ def test_toc() -> bool:
     assert succ and succ_two and succ_three and succ_four and succ_five
 
 
+@pytest.mark.ado_test
 def test_link() -> bool:
     a = ro.reportlinkREST()
     a.get_report_link()
@@ -666,6 +716,7 @@ def test_link() -> bool:
     assert succ and succ_two
 
 
+@pytest.mark.ado_test
 def test_table_merge() -> bool:
     a = ro.tablemergeREST()
     succ = a.get_merging_param() == "row"
@@ -684,6 +735,7 @@ def test_table_merge() -> bool:
     assert succ and succ_two and succ_three and succ_four
 
 
+@pytest.mark.ado_test
 def test_tablemerge_title() -> bool:
     a = ro.tablemergeREST()
     succ = a.get_table_name() == ""
@@ -697,6 +749,7 @@ def test_tablemerge_title() -> bool:
     assert succ and succ_two and succ_three
 
 
+@pytest.mark.ado_test
 def test_tablemerge_source() -> bool:
     a = ro.tablemergeREST()
     succ = a.get_sources() == ["*|duplicate"]
@@ -730,6 +783,7 @@ def test_tablemerge_source() -> bool:
     assert succ_a and succ_b
 
 
+@pytest.mark.ado_test
 def test_tablemerge_tag() -> bool:
     a = ro.tablemergeREST()
     succ = a.get_rename_tag() == ""
@@ -744,6 +798,7 @@ def test_tablemerge_tag() -> bool:
     assert succ and succ_two and succ_three
 
 
+@pytest.mark.ado_test
 def test_tablemerge_labels() -> bool:
     a = ro.tablemergeREST()
     succ = a.get_use_labels() == 1
@@ -762,6 +817,7 @@ def test_tablemerge_labels() -> bool:
     assert succ and succ_two and succ_three and succ_four
 
 
+@pytest.mark.ado_test
 def test_tablemerge_setids() -> bool:
     a = ro.tablemergeREST()
     succ = a.get_use_ids() == ""
@@ -799,6 +855,7 @@ def test_tablemerge_setids() -> bool:
     assert succ_a and succ_b
 
 
+@pytest.mark.ado_test
 def test_tablemerge_ids_one() -> bool:
     a = ro.tablemergeREST()
     succ = a.get_id_selection() == "all"
@@ -817,6 +874,7 @@ def test_tablemerge_ids_one() -> bool:
     assert succ and succ_two and succ_three and succ_four
 
 
+@pytest.mark.ado_test
 def test_tablemerge_ids() -> bool:
     a = ro.tablemergeREST()
     a.params = json.dumps({"merge_params": {"merge_type": "0", "column_merge": "all"}})
@@ -875,6 +933,7 @@ def test_tablemerge_ids() -> bool:
     assert succ_a and succ_b
 
 
+@pytest.mark.ado_test
 def test_tablemerge_unknown() -> bool:
     a = ro.tablemergeREST()
     succ = a.get_unknown_value() == "nan"
@@ -888,6 +947,7 @@ def test_tablemerge_unknown() -> bool:
     assert succ and succ_two and succ_three
 
 
+@pytest.mark.ado_test
 def test_tablemerge_transp() -> bool:
     a = ro.tablemergeREST()
     succ = a.get_table_transpose() == 0
@@ -906,6 +966,7 @@ def test_tablemerge_transp() -> bool:
     assert succ and succ_two and succ_three and succ_four
 
 
+@pytest.mark.ado_test
 def test_tablemerge_numeric() -> bool:
     a = ro.tablemergeREST()
     succ = a.get_numeric_output() == 0
@@ -924,6 +985,7 @@ def test_tablemerge_numeric() -> bool:
     assert succ and succ_two and succ_three and succ_four
 
 
+@pytest.mark.ado_test
 def test_tablemerge_nameparam() -> bool:
     a = ro.tablereduceREST()
     succ = a.get_reduce_param() == "row"
@@ -951,6 +1013,7 @@ def test_tablemerge_nameparam() -> bool:
     assert succ_a and succ_five and succ_six and succ_seven
 
 
+@pytest.mark.ado_test
 def test_tablemerge_operation() -> bool:
     a = ro.tablereduceREST()
     succ = a.get_operations() == []
@@ -1010,6 +1073,7 @@ def test_tablemerge_operation() -> bool:
     assert succ_a and succ_b
 
 
+@pytest.mark.ado_test
 def test_tablemerge_transpose() -> bool:
     a = ro.tablereduceREST()
     succ = a.get_table_transpose() == 0
@@ -1033,6 +1097,7 @@ def test_tablemerge_transpose() -> bool:
     assert succ and succ_two and succ_three and succ_four and succ_five
 
 
+@pytest.mark.ado_test
 def test_tablereduce_numeric() -> bool:
     a = ro.tablereduceREST()
     succ = a.get_numeric_output() == 0
@@ -1051,6 +1116,7 @@ def test_tablereduce_numeric() -> bool:
     assert succ and succ_two and succ_three and succ_four
 
 
+@pytest.mark.ado_test
 def test_tablerowcol() -> bool:
     a = ro.tablerowcolumnfilterREST()
     a = ro.tablerowcolumnfilterREST()
@@ -1092,6 +1158,7 @@ def test_tablerowcol() -> bool:
     assert succ_a and succ_b
 
 
+@pytest.mark.ado_test
 def test_tablerowcol_col() -> bool:
     a = ro.tablerowcolumnfilterREST()
     succ = a.get_filter_columns() == ["*"]
@@ -1123,6 +1190,7 @@ def test_tablerowcol_col() -> bool:
     assert succ and succ_two and succ_three and succ_four and succ_five and succ_six
 
 
+@pytest.mark.ado_test
 def test_tablerowcol_invertsort() -> bool:
     a = ro.tablerowcolumnfilterREST()
     succ = a.get_invert() == 0
@@ -1162,6 +1230,7 @@ def test_tablerowcol_invertsort() -> bool:
     assert succ_a and succ_b
 
 
+@pytest.mark.ado_test
 def test_tablerowcol_transp() -> bool:
     a = ro.tablerowcolumnfilterREST()
     succ = a.get_table_transpose() == 0
@@ -1180,6 +1249,7 @@ def test_tablerowcol_transp() -> bool:
     assert succ and succ_two and succ_three and succ_four
 
 
+@pytest.mark.ado_test
 def test_tablevaluefilter() -> bool:
     a = ro.tablevaluefilterREST()
     succ = a.get_table_name() == ""
@@ -1219,6 +1289,7 @@ def test_tablevaluefilter() -> bool:
     assert succ_a and succ_b
 
 
+@pytest.mark.ado_test
 def test_tablevaluefilter_filter() -> bool:
     a = ro.tablevaluefilterREST()
     a.get_filter()
@@ -1334,6 +1405,7 @@ def test_tablevaluefilter_filter() -> bool:
     assert succ_a + succ_b + succ_c + succ_d + succ_e + succ_f
 
 
+@pytest.mark.ado_test
 def test_tablevaluefilter_filterparams() -> bool:
     a = ro.tablevaluefilterREST()
     a.params = '{"filter": "specific"}'
@@ -1351,6 +1423,7 @@ def test_tablevaluefilter_filterparams() -> bool:
     assert succ_one and succ_two and succ_three and succ_four and succ_five and succ_six
 
 
+@pytest.mark.ado_test
 def test_tablevaluefilter_invertdate() -> bool:
     a = ro.tablevaluefilterREST()
     succ = a.get_invert_filter() == 0
@@ -1384,6 +1457,7 @@ def test_tablevaluefilter_invertdate() -> bool:
     assert succ_a and succ_b
 
 
+@pytest.mark.ado_test
 def test_tablesort() -> bool:
     a = ro.tablesortfilterREST()
     succ = a.get_table_name() == "sorted table"
@@ -1437,6 +1511,7 @@ def test_tablesort() -> bool:
     assert succ_a and succ_b and succ_c
 
 
+@pytest.mark.ado_test
 def test_tablesort_column() -> bool:
     a = ro.tablesortfilterREST()
     succ = a.get_sort_columns() == []
@@ -1475,6 +1550,7 @@ def test_tablesort_column() -> bool:
     assert succ_a and succ_b
 
 
+@pytest.mark.ado_test
 def test_treerule() -> bool:
     a = ro.treemergeREST()
     succ = a.get_merge_rule() == "all"
@@ -1494,6 +1570,7 @@ def test_treerule() -> bool:
     assert succ and succ_two and succ_three and succ_four
 
 
+@pytest.mark.ado_test
 def test_treevalue() -> bool:
     a = ro.treemergeREST()
     succ = False
@@ -1522,6 +1599,7 @@ def test_treevalue() -> bool:
     assert succ_a and succ_b
 
 
+@pytest.mark.ado_test
 def test_sqlite_name() -> bool:
     a = ro.sqlqueriesREST()
     succ = a.get_db_type() == "SQLite"
@@ -1556,6 +1634,7 @@ def test_sqlite_name() -> bool:
     assert succ_a and succ_b
 
 
+@pytest.mark.ado_test
 def test_sqlite_postgre() -> bool:
     a = ro.sqlqueriesREST()
     a.set_db_type(value="SQLite")
@@ -1580,6 +1659,7 @@ def test_sqlite_postgre() -> bool:
     assert succ and succ_two and succ_three and succ_four and succ_five
 
 
+@pytest.mark.ado_test
 def test_squile_query() -> bool:
     a = ro.sqlqueriesREST()
     succ = a.get_query() == ""
@@ -1594,6 +1674,7 @@ def test_squile_query() -> bool:
     assert succ and succ_two and succ_three and succ_four
 
 
+@pytest.mark.ado_test
 def test_pptx() -> bool:
     a = ro.pptxREST()
     a.input_pptx = "a"
@@ -1605,12 +1686,14 @@ def test_pptx() -> bool:
     assert succ and succ_two and succ_three
 
 
+@pytest.mark.ado_test
 def test_pptx_slide() -> bool:
     a = ro.pptxslideREST()
     a.source_slide = "a"
     assert a.source_slide == "a"
 
 
+@pytest.mark.ado_test
 def test_datafilter() -> bool:
     a = ro.datafilterREST()
     a.filter_types = "a"
@@ -1629,6 +1712,7 @@ def test_datafilter() -> bool:
     assert a.filter_single_dropdown == "g"
 
 
+@pytest.mark.ado_test
 def test_unit_template() -> bool:
     a = ro.Template()
     succ = a.get_template_object(guid="a") is None
@@ -1647,6 +1731,7 @@ def test_unit_template() -> bool:
     assert succ and succ_two and succ_three and succ_four
 
 
+@pytest.mark.ado_test
 def test_unit_base() -> bool:
     a = ro.BaseRESTObject()
     succ_two = a.add_quotes(s=" 'abc' ") == "' 'abc' '"

--- a/tests/test_report_remote_server.py
+++ b/tests/test_report_remote_server.py
@@ -15,14 +15,21 @@ from ansys.dynamicreporting.core.utils.exceptions import DBCreationFailedError
 from .conftest import cleanup_docker
 
 
-def test_copy_item(adr_service_query, request) -> bool:
+def test_copy_item(adr_service_query, request, get_exec) -> bool:
     db_dir = join(join(request.fspath.dirname, "test_data"), "newcopy")
-    tmp_adr = Service(
-        ansys_installation="docker",
-        docker_image=DOCKER_DEV_REPO_URL,
-        db_directory=db_dir,
-        port=8000 + int(random() * 4000),
-    )
+    if get_exec != "":
+        tmp_adr = Service(
+            ansys_installation=get_exec,
+            db_directory=db_dir,
+            port=8000 + int(random() * 4000),
+        )
+    else:
+        tmp_adr = Service(
+            ansys_installation="docker",
+            docker_image=DOCKER_DEV_REPO_URL,
+            db_directory=db_dir,
+            port=8000 + int(random() * 4000),
+        )
     tmp_adr.start(create_db=True, exit_on_close=True, delete_db=True)
     s = tmp_adr.serverobj
     succ = s.copy_items(
@@ -30,20 +37,28 @@ def test_copy_item(adr_service_query, request) -> bool:
     )
     adr_service_query.stop()
     tmp_adr.stop()
-    cleanup_docker(request)
+    if get_exec == "":
+        cleanup_docker(request)
     assert succ
 
 
-def test_start_stop(request) -> bool:
-    cleanup_docker(request)
+def test_start_stop(request, get_exec) -> bool:
     db_dir = join(join(request.fspath.dirname, "test_data"), "create_delete")
     port_r = 8000 + int(random() * 4000)
-    tmp_adr = Service(
-        ansys_installation="docker",
-        docker_image=DOCKER_DEV_REPO_URL,
-        db_directory=db_dir,
-        port=port_r,
-    )
+    if get_exec != "":
+        tmp_adr = Service(
+            ansys_installation=get_exec,
+            db_directory=db_dir,
+            port=port_r,
+        )
+    else:
+        cleanup_docker(request)
+        tmp_adr = Service(
+            ansys_installation="docker",
+            docker_image=DOCKER_DEV_REPO_URL,
+            db_directory=db_dir,
+            port=port_r,
+        )
     succ = True
     try:
         r.create_new_local_database(
@@ -79,16 +94,23 @@ def test_validate_existing(adr_service_query) -> bool:
     assert succ
 
 
-def test_fail_newdb(request) -> bool:
-    cleanup_docker(request)
+def test_fail_newdb(request, get_exec) -> bool:
     db_dir = join(join(request.fspath.dirname, "test_data"), "create_twice")
     port_r = 8000 + int(random() * 4000)
-    tmp_adr = Service(
-        ansys_installation="docker",
-        docker_image=DOCKER_DEV_REPO_URL,
-        db_directory=db_dir,
-        port=port_r,
-    )
+    if get_exec != "":
+        tmp_adr = Service(
+            ansys_installation=get_exec,
+            db_directory=db_dir,
+            port=port_r,
+        )
+    else:
+        cleanup_docker(request)
+        tmp_adr = Service(
+            ansys_installation="docker",
+            docker_image=DOCKER_DEV_REPO_URL,
+            db_directory=db_dir,
+            port=port_r,
+        )
     succ = True
     try:
         r.create_new_local_database(
@@ -305,16 +327,23 @@ def test_get_pptx(adr_service_query, request) -> bool:
     assert success is True
 
 
-def test_copy_template(adr_service_query, request) -> bool:
+def test_copy_template(adr_service_query, request, get_exec) -> bool:
     db_dir = join(join(request.fspath.dirname, "test_data"), "newcopytemp")
     if isdir(db_dir):
         shutil.rmtree(db_dir)
-    tmp_adr = Service(
-        ansys_installation="docker",
-        docker_image=DOCKER_DEV_REPO_URL,
-        db_directory=db_dir,
-        port=8000 + int(random() * 4000),
-    )
+    if get_exec != "":
+        tmp_adr = Service(
+            ansys_installation=get_exec,
+            db_directory=db_dir,
+            port=8000 + int(random() * 4000),
+        )
+    else:
+        tmp_adr = Service(
+            ansys_installation="docker",
+            docker_image=DOCKER_DEV_REPO_URL,
+            db_directory=db_dir,
+            port=8000 + int(random() * 4000),
+        )
     tmp_adr.start(create_db=True, exit_on_close=True, delete_db=True)
     s = tmp_adr.serverobj
     succ = s.copy_items(
@@ -322,7 +351,8 @@ def test_copy_template(adr_service_query, request) -> bool:
     )
     adr_service_query.stop()
     tmp_adr.stop()
-    cleanup_docker(request)
+    if get_exec == '':
+        cleanup_docker(request)
     assert succ
 
 
@@ -342,16 +372,23 @@ def test_groups(adr_service_create, request) -> bool:
     assert succ and succ_two and succ_three
 
 
-def test_acls_start(request) -> bool:
-    cleanup_docker(request)
+def test_acls_start(request, get_exec) -> bool:
     db_dir = join(join(request.fspath.dirname, "test_data"), "create_delete")
     port_r = 8000 + int(random() * 4000)
-    tmp_adr = Service(
-        ansys_installation="docker",
-        docker_image=DOCKER_DEV_REPO_URL,
-        db_directory=db_dir,
-        port=port_r,
-    )
+    if get_exec != "":
+        tmp_adr = Service(
+            ansys_installation=get_exec,
+            db_directory=db_dir,
+            port=port_r,
+        )
+    else:
+        cleanup_docker(request)
+        tmp_adr = Service(
+            ansys_installation="docker",
+            docker_image=DOCKER_DEV_REPO_URL,
+            db_directory=db_dir,
+            port=port_r,
+        )
     r.create_new_local_database(
         parent=None,
         directory=db_dir,

--- a/tests/test_report_remote_server.py
+++ b/tests/test_report_remote_server.py
@@ -1,6 +1,7 @@
 from os import environ
 from os.path import isdir, join
 from random import random
+import pytest
 import shutil
 import uuid
 
@@ -42,6 +43,7 @@ def test_copy_item(adr_service_query, request, get_exec) -> bool:
     assert succ
 
 
+@pytest.mark.ado_test
 def test_start_stop(request, get_exec) -> bool:
     db_dir = join(join(request.fspath.dirname, "test_data"), "create_delete")
     port_r = 8000 + int(random() * 4000)
@@ -173,6 +175,7 @@ def test_server_token(adr_service_create) -> bool:
     assert succ and succ_two and succ_three and succ_four and succ_five
 
 
+@pytest.mark.ado_test
 def test_server_guids(adr_service_create) -> bool:
     _ = adr_service_create.start(
         create_db=True,
@@ -188,6 +191,7 @@ def test_server_guids(adr_service_create) -> bool:
     assert succ and succ_two and succ_three
 
 
+@pytest.mark.ado_test
 def test_default() -> bool:
     s = r.Server()
     succ = False
@@ -206,11 +210,13 @@ def test_default() -> bool:
     assert succ and succ_two and succ_three
 
 
+@pytest.mark.ado_test
 def test_template() -> bool:
     s = r.Server()
     assert isinstance(s.create_template(parent=s.create_template()), ro.basicREST)
 
 
+@pytest.mark.ado_test
 def test_url_query() -> bool:
     s = r.Server()
     s.cur_url = "http://localhost:8000"
@@ -266,6 +272,7 @@ def test_export_html(adr_service_query) -> bool:
     assert success is True
 
 
+@pytest.mark.ado_test
 def test_export_pdf(adr_service_query, get_exec) -> bool:
     exec_basis = get_exec
     success = False
@@ -299,6 +306,7 @@ def test_export_pdf(adr_service_query, get_exec) -> bool:
     assert success is True
 
 
+@pytest.mark.ado_test
 def test_export_pptx(adr_service_query) -> bool:
     success = False
     try:

--- a/tests/test_report_remote_server.py
+++ b/tests/test_report_remote_server.py
@@ -1,3 +1,4 @@
+from os import environ
 from os.path import isdir, join
 from random import random
 import shutil
@@ -253,14 +254,18 @@ def test_export_pdf(adr_service_query, get_exec) -> bool:
         success = False
     s = adr_service_query.serverobj
     if exec_basis:
-        import re
+        if environ.get("ANSYS_REL_INT_I"):
+            ansys_version = int(environ.get("ANSYS_REL_INT_I"))
+        else:
+            import re
 
-        matches = re.search(r".*v([0-9]{3}).*", exec_basis)
+            matches = re.search(r".*v([0-9]{3}).*", exec_basis)
+            ansys_version = int(matches.group(1))
         s.export_report_as_pdf(
             report_guid=my_report.report.guid,
             file_name="mytest",
             exec_basis=exec_basis,
-            ansys_version=int(matches.group(1)),
+            ansys_version=ansys_version,
         )
     else:
         # If no local installation, then you can not run the routine for pdf conversion. OSError expected.

--- a/tests/test_report_utils.py
+++ b/tests/test_report_utils.py
@@ -104,6 +104,7 @@ def test_from_local_8bit() -> bool:
 
 def test_run_web_request(adr_service_query) -> bool:
     resp = ru.run_web_request(method="GET", server=adr_service_query.serverobj, relative_url="")
+    adr_service_query.stop()
     assert resp.ok is True
 
 

--- a/tests/test_report_utils.py
+++ b/tests/test_report_utils.py
@@ -1,6 +1,7 @@
 from os.path import join
 
 import numpy as np
+import pytest
 
 from ansys.dynamicreporting.core.utils import report_utils as ru
 
@@ -16,6 +17,7 @@ def return_file_paths(request) -> list:
     return [image_file, scene_file, ens_file, evsn_file, scdoc_file, csf_file]
 
 
+@pytest.mark.ado_test
 def test_encode_decode() -> bool:
     mys = "D:\tmp\\My String()"
     encoded_s = ru.encode_url(mys)
@@ -23,26 +25,31 @@ def test_encode_decode() -> bool:
     assert mys == decoded_s
 
 
+@pytest.mark.ado_test
 def test_is_enve_image(request) -> bool:
     no_img = ru.is_enve_image(return_file_paths(request)[0])
     assert no_img is False
 
 
+@pytest.mark.ado_test
 def test_enve_image_to_data(request) -> bool:
     no_img = ru.enve_image_to_data(return_file_paths(request)[0])
     assert no_img is None
 
 
+@pytest.mark.ado_test
 def test_env_arch() -> bool:
     local_arch = ru.enve_arch()
     assert ("win" in local_arch) or ("lin" in local_arch)
 
 
+@pytest.mark.ado_test
 def test_enve_home() -> bool:
     enve_home = ru.enve_home()
     assert "ansys" in enve_home
 
 
+@pytest.mark.ado_test
 def test_ceiversion_nexus_suffix() -> bool:
     suffix = ru.ceiversion_nexus_suffix()
     try:
@@ -53,6 +60,7 @@ def test_ceiversion_nexus_suffix() -> bool:
     assert success and int_suffix / 100 < 10
 
 
+@pytest.mark.ado_test
 def test_ceiversion_apex_suffix() -> bool:
     suffix = ru.ceiversion_apex_suffix()
     try:
@@ -63,6 +71,7 @@ def test_ceiversion_apex_suffix() -> bool:
     assert success and int_suffix / 100 < 10
 
 
+@pytest.mark.ado_test
 def test_ceiversion_ensight_suffix() -> bool:
     suffix = ru.ceiversion_ensight_suffix()
     try:
@@ -73,52 +82,62 @@ def test_ceiversion_ensight_suffix() -> bool:
     assert success and int_suffix / 100 < 10
 
 
+@pytest.mark.ado_test
 def test_platform_encoding() -> bool:
     encode = ru.platform_encoding()
     assert encode == "mbcs" or encode == "utf-8"
 
 
+@pytest.mark.ado_test
 def test_local_to_utf8() -> bool:
     testone = ru.local_to_utf8(v=b"33")
     testtwo = ru.local_to_utf8(v=b"33", use_unicode=True)
     assert type(testone) is bytes and type(testtwo) is str
 
 
+@pytest.mark.ado_test
 def test_utf8_to_local() -> bool:
     assert type(ru.utf8_to_local(v="rr")) is bytes
 
 
+@pytest.mark.ado_test
 def test_utf8_to_unicode() -> bool:
     assert type(ru.utf8_to_unicode(v="rr")) is str and type(ru.utf8_to_unicode(v=b"rr"))
 
 
+@pytest.mark.ado_test
 def test_to_local_8bit() -> bool:
     assert type(ru.to_local_8bit(v="rr")) is str
 
 
+@pytest.mark.ado_test
 def test_from_local_8bit() -> bool:
     testone = ru.from_local_8bit(v=b"33")
     testtwo = ru.from_local_8bit(v="33")
     assert type(testone) is str and type(testtwo) is str
 
 
+@pytest.mark.ado_test
 def test_run_web_request(adr_service_query) -> bool:
     resp = ru.run_web_request(method="GET", server=adr_service_query.serverobj, relative_url="")
     adr_service_query.stop()
     assert resp.ok is True
 
 
+@pytest.mark.ado_test
 def test_isSQLite3(request) -> bool:
     test_path = join(request.fspath.dirname, "test_data")
     slite_file = join(join(test_path, "query_db"), "db.sqlite3")
     assert ru.isSQLite3(slite_file) is True
 
 
+@pytest.mark.ado_test
 def test_no_isSQLite3(request) -> bool:
     slite_file = return_file_paths(request)[0]
     assert ru.isSQLite3(slite_file) is False
 
 
+@pytest.mark.ado_test
 def test_narray() -> bool:
     try:
         a = ru.nexus_array(dtype="u8", shape=(1, 2))
@@ -151,6 +170,7 @@ def test_narray() -> bool:
     assert success
 
 
+@pytest.mark.ado_test
 def test_narray_index() -> bool:
     a = ru.nexus_array()
     mystr = a._index(key="a")
@@ -158,6 +178,7 @@ def test_narray_index() -> bool:
     assert mystr == "a" and myint == 2
 
 
+@pytest.mark.ado_test
 def test_narray_getitem() -> bool:
     b = ru.nexus_array()
     b.__setitem__(key=0, value=10)
@@ -168,6 +189,7 @@ def test_narray_getitem() -> bool:
     assert myval == 10 and type(myb) is bytes
 
 
+@pytest.mark.ado_test
 def test_settings() -> bool:
     try:
         _ = ru.Settings(defaults={"a": 1, "b": 2})
@@ -177,6 +199,7 @@ def test_settings() -> bool:
     assert success
 
 
+@pytest.mark.ado_test
 def test_find_unused_ports() -> bool:
     ports = ru.find_unused_ports(count=3)
     single_port = ru.find_unused_ports(start=0, end=9000, count=1, avoid=range(10, 1000))
@@ -185,6 +208,7 @@ def test_find_unused_ports() -> bool:
     assert len(ports) == 3 and len(single_port) == 1 and succ and succ_two
 
 
+@pytest.mark.ado_test
 def test_is_port_in_use() -> bool:
     ret_f = ru.is_port_in_use(port=-34)
     ret_t = ru.is_port_in_use(port=9090)
@@ -192,11 +216,13 @@ def test_is_port_in_use() -> bool:
     assert ret_f is False and ret_t is False and ret_less is False
 
 
+@pytest.mark.ado_test
 def test_get_links_from_html() -> bool:
     res = ru.get_links_from_html(html="www.mocksite.com")
     assert res == []
 
 
+@pytest.mark.ado_test
 def test_htmlparser() -> bool:
     a = ru.HTMLParser()
     a.handle_starttag(tag="a", attrs=[("href", 1)])

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -2,6 +2,7 @@
 
 
 from os.path import join
+import pytest
 from random import random
 
 from ansys.dynamicreporting.core import Report, Service, docker_support
@@ -12,6 +13,7 @@ from ansys.dynamicreporting.core.utils import report_remote_server
 from .conftest import cleanup_docker
 
 
+@pytest.mark.ado_test
 def test_unit_nexus() -> bool:
     valid = False
     a = Service()
@@ -22,6 +24,7 @@ def test_unit_nexus() -> bool:
     assert valid
 
 
+@pytest.mark.ado_test
 def test_unit_nexus_nosession(request) -> bool:
     logfile = join(request.fspath.dirname, "outfile7.txt")
     a = Service(logfile=logfile)
@@ -34,6 +37,7 @@ def test_unit_nexus_nosession(request) -> bool:
     assert err_msg
 
 
+@pytest.mark.ado_test
 def test_unit_nodbpath(request) -> bool:
     logfile = join(request.fspath.dirname, "outfile8.txt")
     a = Service(logfile=logfile, db_directory="aaa")
@@ -46,6 +50,7 @@ def test_unit_nodbpath(request) -> bool:
     assert err_msg
 
 
+@pytest.mark.ado_test
 def test_unit_nexus_stop(request) -> bool:
     logfile = join(request.fspath.dirname, "outfile.txt")
     a = Service(logfile=logfile)
@@ -54,6 +59,7 @@ def test_unit_nexus_stop(request) -> bool:
     assert "There is no service connected to the current session" in f.read()
 
 
+@pytest.mark.ado_test
 def test_unit_nexus_connect(request) -> bool:
     logfile = join(request.fspath.dirname, "outfile_2.txt")
     a = Service(logfile=logfile)
@@ -66,6 +72,7 @@ def test_unit_nexus_connect(request) -> bool:
     assert err_msg
 
 
+@pytest.mark.ado_test
 def test_unit_createitem() -> bool:
     a = Service()
     a.serverobj = report_remote_server.Server()
@@ -77,6 +84,7 @@ def test_unit_createitem() -> bool:
     assert valid
 
 
+@pytest.mark.ado_test
 def test_unit_query() -> bool:
     a = Service()
     a.serverobj = report_remote_server.Server()
@@ -84,18 +92,21 @@ def test_unit_query() -> bool:
     assert query_list == []
 
 
+@pytest.mark.ado_test
 def test_unit_invalidqueryone() -> bool:
     a = Service()
     valid = a.__check_filter__("F|i_type|cont|html;")
     assert valid is False
 
 
+@pytest.mark.ado_test
 def test_unit_invalidquerytwo() -> bool:
     a = Service()
     valid = a.__check_filter__("A|b_type|cont|html;")
     assert valid is False
 
 
+@pytest.mark.ado_test
 def test_unit_delete_invalid(request) -> bool:
     logfile = join(request.fspath.dirname, "outfile_4.txt")
     a = Service(logfile=logfile)
@@ -109,6 +120,7 @@ def test_unit_delete_invalid(request) -> bool:
     assert err_msg
 
 
+@pytest.mark.ado_test
 def test_unit_delete() -> bool:
     a = Service()
     a.serverobj = report_remote_server.Server()
@@ -116,6 +128,7 @@ def test_unit_delete() -> bool:
     assert ret is False
 
 
+@pytest.mark.ado_test
 def test_unit_get_report(request) -> bool:
     logfile = join(request.fspath.dirname, "outfile_5.txt")
     a = Service(logfile=logfile)
@@ -128,6 +141,7 @@ def test_unit_get_report(request) -> bool:
     assert err_msg
 
 
+@pytest.mark.ado_test
 def test_unit_get_listreport(request) -> bool:
     logfile = join(request.fspath.dirname, "outfile_9.txt")
     a = Service(logfile=logfile)
@@ -140,6 +154,7 @@ def test_unit_get_listreport(request) -> bool:
     assert err_msg
 
 
+@pytest.mark.ado_test
 def test_no_directory() -> bool:
     success = True
     try:
@@ -220,6 +235,7 @@ def test_create_on_existing(request, get_exec) -> bool:
     assert session_id == "0"
 
 
+@pytest.mark.ado_test
 def test_stop_before_starting(adr_service_create) -> bool:
     success = adr_service_create.stop()
     assert success
@@ -230,12 +246,14 @@ def test_get_sessionid(adr_service_create) -> bool:
     assert session_id == adr_service_create.session_guid
 
 
+@pytest.mark.ado_test
 def test_query_sessions(adr_service_query) -> bool:
     len_queried = len(adr_service_query.query(query_type="Session"))
     adr_service_query.stop()
     assert 3 == len_queried
 
 
+@pytest.mark.ado_test
 def test_query_dataset(adr_service_query) -> bool:
     len_queried = len(adr_service_query.query(query_type="Dataset"))
     adr_service_query.stop()
@@ -249,9 +267,9 @@ def test_query_table(adr_service_query) -> bool:
     assert 1 == len(only_table)
 
 
+@pytest.mark.ado_test
 def test_delete_item(adr_service_query) -> bool:
     only_text = adr_service_query.query(query_type="Item", filter="A|i_type|cont|html")
-    # a_text = only_text[0].item_text
     ret = adr_service_query.delete(only_text)
     newly_items = adr_service_query.query(query_type="Item", filter="A|i_type|cont|html")
     adr_service_query.stop()
@@ -292,6 +310,7 @@ def test_vis_report_name(adr_service_query) -> bool:
     assert success is None
 
 
+@pytest.mark.ado_test
 def test_connect_to_running(adr_service_query, request, get_exec) -> bool:
     # Connect to a running service and make sure you can access the same dataset
     db_dir = join(join(request.fspath.dirname, "test_data"), "query_db")
@@ -341,6 +360,7 @@ def test_docker_unit() -> bool:
     assert succ and succ_two and succ_three and succ_four and succ_five
 
 
+@pytest.mark.ado_test
 def test_exception() -> bool:
     a = PyadrException()
     succ = a.__str__() == "An error occurred."


### PR DESCRIPTION
Multiple fixes, to allow a subsection of the testing suite to be ran as part of the ADR builds inside the Ansys ecosystem. Changes to the docs to allow for images instead of default thumbnail in the example section

- In the Service class, if the ansys_installation directory doesn't have an Ansys-like structure, allow for it to be set by env. variable (same for ansys_version). This allows for running against a local development build of ADR
- Create a pytest marker to sub-select the tests to be ran inside the Ansys dev. ecosystem
- Make the tests more stable when running against a local installation/build instead of against the docker image

- Use images from examples as thumbnails when available, instead of always using the default thumbnail image.
- Fix typo in docs