### PR TITLE
fix: avoid checking links - process stalls

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -119,6 +119,7 @@ jobs:
         uses: ansys/actions/doc-build@v4
         with:
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
+          check-links: false
 
   package:
     name: Package library

--- a/.github/workflows/nightly-docs.yml
+++ b/.github/workflows/nightly-docs.yml
@@ -22,6 +22,7 @@ jobs:
         uses: ansys/actions/doc-build@v4
         with:
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
+          check-links: false
 
   docs_upload:
     needs: docs_build


### PR DESCRIPTION
For some reason, checking the links stalls in this library. Let's solve the issue first and then attempt to figure out why