### PR TITLE
Add links for doc and cheat sheet

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,22 +35,34 @@ PyDynamicReporting
 
 Overview
 --------
-The ``pydynamicreporting`` repository contains the Python client library for
-Ansys Dynamic Reporting, previously documented as `Nexus`_. Ansys Dynamic
-Reporting is a service for pushing items of many types, including images, text,
-3D scenes, and tables, into a database, where you can keep them organized and
-create dynamic reports from them. When you use PyDynamicReporting to connect to
-an instance of Ansys Dynamic Reporting, you have a Pythonic way of accessing all
-capabilities of Ansys Dynamic Reporting.
+PyDynamicReporting is the Python client library for Ansys Dynamic Reporting,
+previously documented as `Nexus`_. Ansys Dynamic Reporting is a service for
+pushing items of many types, including images, text, 3D scenes, and tables,
+into a database, where you can keep them organized and create dynamic reports
+from them. When you use PyDynamicReporting to connect to an instance of
+Ansys Dynamic Reporting, you have a Pythonic way of accessing all capabilities
+of Ansys Dynamic Reporting.
 
 Documentation and issues
 ------------------------
-For comprehensive information on PyDynamicReporting, see the latest release
-`documentation <https://dynamicreporting.docs.pyansys.com>`_.
+Documentation for the latest stable release of PyDynamicReporting is hosted at
+`PyDynamicReporting documentation <https://dynamicreporting.docs.pyansys.com/version/stable/>`_.
+
+In the upper right corner of the documentation's title bar, there is an option
+for switching from viewing the documentation for the latest stable release
+to viewing the documentation for the development version or previously
+released versions.
+
+You can also `view <https://cheatsheets.docs.pyansys.com/pydynamicreporting_cheat_sheet.png>`_ or
+`download <https://cheatsheets.docs.pyansys.com/pydynamicreporting_cheat_sheet.pdf>`_ the
+PyDynamicReporting cheat sheet. This one-page reference provides syntax rules and commands
+for using PyDynamicReporting.
 
 On the `PyDynamicReporting Issues <https://github.com/ansys/pydynamicreporting/issues>`_
-page, you can create issues to submit questions, report bugs, and request new
-features. This is the best place to post questions and code.
+page, you can create issues to report bugs and request new features. On the `Discussions <https://discuss.ansys.com/>`_
+page on the Ansys Developer portal, you can post questions, share ideas, and get community feedback.
+
+To reach the project support team, email `pyansys.core@ansys.com <pyansys.core@ansys.com>`_.
 
 Installation
 ------------

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -37,15 +37,26 @@ a Python client library that allows you to start and connect to an Ansys Dynamic
 service and control the database and reports. It also provides you with quick access to web
 components so that you can easily embed items or reports in other apps.
 
-
 Documentation and issues
 ------------------------
-For comprehensive information on PyDynamicReporting, see the latest release
-`documentation <https://dynamicreporting.docs.pyansys.com>`_.
+Documentation for the latest stable release of PyDynamicReporting is hosted at
+`PyDynamicReporting documentation <https://dynamicreporting.docs.pyansys.com/version/stable/>`_.
+
+In the upper right corner of the documentation's title bar, there is an option
+for switching from viewing the documentation for the latest stable release
+to viewing the documentation for the development version or previously
+released versions.
+
+You can also `view <https://cheatsheets.docs.pyansys.com/pydynamicreporting_cheat_sheet.png>`_ or
+`download <https://cheatsheets.docs.pyansys.com/pydynamicreporting_cheat_sheet.pdf>`_ the
+PyDynamicReporting cheat sheet. This one-page reference provides syntax rules and commands
+for using PyDynamicReporting.
 
 On the `PyDynamicReporting Issues <https://github.com/ansys/pydynamicreporting/issues>`_
-page, you can create issues to submit questions, report bugs, and request new
-features. This is the best place to post questions and code.
+page, you can create issues to report bugs and request new features. On the `Discussions <https://discuss.ansys.com/>`_
+page on the Ansys Developer portal, you can post questions, share ideas, and get community feedback.
+
+To reach the project support team, email `pyansys.core@ansys.com <pyansys.core@ansys.com>`_.
 
 License
 -------


### PR DESCRIPTION
Per Landon’s request in the PyAnsys Global AFT on 7/26/23, add links to the PyDynamicReporting cheat sheet from this library's documentation.

Note: This library doesn't reuse the README content in the overall index.rst file for documentation. Consequently, I revised the "Documentation and issues" sections in both the README and the overall index.rst file.

Also, see Issue #34. The content added to this repo couldn't link to a Discussions page for the repo because there isn't one.