### PR TITLE
Workaround a Linux TZ issue

### DIFF
--- a/src/ansys/dynamicreporting/core/utils/report_remote_server.py
+++ b/src/ansys/dynamicreporting/core/utils/report_remote_server.py
@@ -1005,6 +1005,9 @@ def create_new_local_database(
 
         return False
 
+    # Check for Linux TZ issue
+    report_utils.apply_timezone_workaround()
+
     try:
         if run_local:
             # Make a random string that could be used as a secret key for the database
@@ -1347,6 +1350,9 @@ def launch_local_database_server(
 
     if return_info is None:
         return_info = dict()
+
+    # Check for Linux TZ issue
+    report_utils.apply_timezone_workaround()
 
     # Try to use a lock file to prevent port scanning collisions
     # We create a lockfiles in the user's home directory.  Under windows, we use LOCALAPPDATA to avoid

--- a/src/ansys/dynamicreporting/core/utils/report_utils.py
+++ b/src/ansys/dynamicreporting/core/utils/report_utils.py
@@ -739,3 +739,30 @@ def get_links_from_html(html):
     parser = HTMLParser()
     parser.feed(html)
     return parser.links
+
+
+def apply_timezone_workaround() -> None:
+    """Apply a workaround for known Linux system misconfigurations
+
+    There is a known issue on some Linux systems where the timezone configuration is incorrect.
+    On these systems, the get_localzone_name() call will raise an exception that prevents a
+    Django instance from starting.  This effects the Nexus server as well as the adr API for
+    doing things like creating a database.
+
+    The work-around is to try to trigger the exception early and (on failure) set the TZ
+    environmental variable  to a known value and warn the user that this has been done.
+    If the user sets TZ or corrects the system misconfiguration, that will also fix the
+    issue.
+
+    """
+    try:
+        # Attempt to trigger the misconfiguration issue.
+        import tzlocal
+        _ = tzlocal.get_localzone_name()
+    except KeyError as e:
+        # Issue a warning
+        import warnings
+        msg = "The timezone of this session is not configured correctly, trying 'US/Eastern' : "
+        warnings.warn(msg + str(e))
+        # Try a relatively well known TZ
+        os.environ["TZ"] = "US/Eastern"


### PR DESCRIPTION
If Linux timezone settings are misconfigured, it can cause adr database creation and nexus server launching to fail.