### PR TITLE
Set obj_name for ADR items to always be a string

### DIFF
--- a/codegen/pyadritem.txt
+++ b/codegen/pyadritem.txt
@@ -88,7 +88,7 @@ class Item:
         self._url = None
         self.logger = service.logger
         self.source = source
-        self.obj_name = obj_name
+        self.obj_name = str(obj_name)
         self.type = None
         self.item_text = ""
         """Text (HTML and LaTeX formatting)"""

--- a/src/ansys/dynamicreporting/core/adr_service.py
+++ b/src/ansys/dynamicreporting/core/adr_service.py
@@ -717,7 +717,7 @@ class Service:
             ret = adr_service.connect()
             my_img = adr_service.create_item()
         """
-        a = Item(service=self, obj_name=obj_name, source=source)
+        a = Item(service=self, obj_name=str(obj_name), source=source)
         return a
 
     def query(self, query_type: str = "Item", filter: Optional[str] = "") -> list:


### PR DESCRIPTION
Make sure that the name for ADR Items is always a string. If not, weird errors happen down the line