### PR TITLE
Feat/pdf export resize

### DIFF
--- a/tests/test_report_remote_server.py
+++ b/tests/test_report_remote_server.py
@@ -296,6 +296,13 @@ def test_export_pdf(adr_service_query, get_exec) -> bool:
             exec_basis=exec_basis,
             ansys_version=ansys_version,
         )
+        s.export_report_as_pdf(
+            report_guid=my_report.report.guid,
+            file_name="mytest",
+            exec_basis=exec_basis,
+            ansys_version=ansys_version,
+            image_size=True,
+        )
     else:
         # If no local installation, then you can not run the routine for pdf conversion. OSError expected.
         try:


### PR DESCRIPTION
Add to the export pdf capability the feature to set width and height on all items so that two images will fit into a single page. Logos will not be resized. If footer templates are present, they're used in the export.