### PR TITLE
add exclude_from_toc for pptx slide layouts

### DIFF
--- a/src/ansys/dynamicreporting/core/utils/report_objects.py
+++ b/src/ansys/dynamicreporting/core/utils/report_objects.py
@@ -3263,6 +3263,16 @@ class pptxslideREST(LayoutREST):
         props["source_slide"] = value
         self.set_property(props)
 
+    @property
+    def exclude_from_toc(self):
+        return self.get_property().get("exclude_from_toc")
+
+    @exclude_from_toc.setter
+    def exclude_from_toc(self, value):
+        props = self.get_property()
+        props["exclude_from_toc"] = value
+        self.set_property(props)
+
 
 class datafilterREST(LayoutREST):
     """Representation of Data Filter Layout Template."""

--- a/tests/test_report_objects.py
+++ b/tests/test_report_objects.py
@@ -1692,6 +1692,8 @@ def test_pptx_slide() -> bool:
     a = ro.pptxslideREST()
     a.source_slide = "a"
     assert a.source_slide == "a"
+    a.exclude_from_toc = "1"
+    assert a.exclude_from_toc == "1"
 
 
 @pytest.mark.ado_test


### PR DESCRIPTION
as requested by Fluent - allows excluding a slide from the table of contents