### PR TITLE
remove pyansys_docker fork dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "filelock>=3.7.1",
     "numpy>=1.18.0",
     "packaging>=21.0",
-    "pyansys-docker>=5.0.4",
+    "docker>=6.1.0",
     "pypng>=0.20220715.0",
     "python-dateutil>=2.8.0",
     "pytz>=2021.3",
@@ -63,7 +63,7 @@ ci =  "https://github.com/ansys/pydynamicreporting/actions"
 
 [project.optional-dependencies]
 tests = [
-    "pyansys-docker==5.0.4",
+    "docker>=6.1.0",
     "numpy==1.25.1",
     "psutil==5.9.5",
     "pytest==7.4.2",
@@ -73,7 +73,7 @@ doc = [
     "ansys-sphinx-theme==0.11.2",
     "numpydoc==1.5.0",
     "pillow==10.0.1",
-    "pyansys-docker==5.0.4",
+    "docker>=6.1.0",
     "Sphinx==7.2.6",
     "sphinx-copybutton==0.5.2",
     "sphinx-gallery==0.14.0",
@@ -87,7 +87,7 @@ dev = [
     "numpydoc==1.5.0",
     "pillow==10.0.1",
     "psutil==5.9.5",
-    "pyansys-docker==5.0.4",
+    "docker>=6.1.0",
     "pytest==7.4.2",
     "pytest-cov==4.1.0",
     "Sphinx==7.2.6",


### PR DESCRIPTION
to align with PyEnSight, I removed the pyansys_docker fork dependency no more required for the updated official docker module