### PR TITLE
Change logging default value to be error

### DIFF
--- a/codegen/adr_utils.txt
+++ b/codegen/adr_utils.txt
@@ -60,7 +60,7 @@ def get_logger(logfile=None):
             The logger object.
     """
     logger = logging.getLogger()
-    logger.setLevel(logging.DEBUG)
+    logger.setLevel(logging.ERROR)
     if logfile is None:
         # Logging for Python APIs should be disabled by default
         ch = logging.NullHandler()
@@ -68,7 +68,7 @@ def get_logger(logfile=None):
         ch = logging.StreamHandler(sys.stdout)
     else:
         ch = logging.FileHandler(logfile)
-    ch.setLevel(logging.DEBUG)
+    ch.setLevel(logging.ERROR)
     formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
     ch.setFormatter(formatter)
     logger.addHandler(ch)

--- a/src/ansys/dynamicreporting/core/adr_service.py
+++ b/src/ansys/dynamicreporting/core/adr_service.py
@@ -544,7 +544,7 @@ class Service:
         except Exception:
             pass
         if v is False:
-            self.logger.warning("Error validating the connected service. Can't shut it down.\n")
+            self.logger.error("Error validating the connected service. Can't shut it down.\n")
         else:
             # If coming from a docker image, clean that up
             try:
@@ -556,7 +556,7 @@ class Service:
                     self.logger.info("Told service to shutdown.\n")
                     self.serverobj.stop_local_server()
             except Exception as e:
-                self.logger.warning(f"Problem shutting down service.\n{str(e)}\n")
+                self.logger.error(f"Problem shutting down service.\n{str(e)}\n")
                 pass
 
         if self._delete_db and self._db_directory:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -64,7 +64,7 @@ def test_unit_nexus_stop(request) -> bool:
     a = Service(logfile=logfile)
     a.stop()
     f = open(logfile)
-    assert "There is no service connected to the current session" in f.read()
+    assert "Error validating the connected service" in f.read()
 
 
 @pytest.mark.ado_test


### PR DESCRIPTION
Change logging default value to match the one used by pyensight, so that scripts that use both pydynamicreporting and pyensight do not run into unexpected outputs as the logging level is overwritten.