### PR TITLE
Ensure that three.js is downloaded for offline HTML

### DIFF
--- a/src/ansys/dynamicreporting/core/utils/report_download_html.py
+++ b/src/ansys/dynamicreporting/core/utils/report_download_html.py
@@ -154,7 +154,7 @@ class ReportDownloadHTML:
 
         # Additional files to be mapped to the media directory
         images = ["menu_20_gray.png", "menu_20_white.png", "nexus_front_page.png", "nexus_logo.png"]
-        self._download_static_files(images, "/static/website/images/", "media", "image")
+        self._download_static_files(images, "/static/website/images/", "media", "nexus images")
 
         # The old Ansys Nexus WebGL viewer
         images = [
@@ -169,7 +169,7 @@ class ReportDownloadHTML:
             "open.png",
             "Point.cur",
         ]
-        self._download_static_files(images, "/static/website/images/", "media", "viewer image")
+        self._download_static_files(images, "/static/website/images/", "media", "viewer images I")
 
         # The new Ansys Nexus WebGL viewer
         images = [
@@ -187,14 +187,16 @@ class ReportDownloadHTML:
             "play.png",
         ]
         self._download_static_files(
-            images, "/ansys/nexus/images/", "ansys/nexus/images/", "viewer image"
+            images, "/ansys/nexus/images/", "ansys/nexus/images/", "viewer images II"
         )
         images = ["js-inflate.js", "js-unzip.js", "jquery.min.js"]
         self._download_static_files(
-            images, "/ansys/nexus/utils/", "ansys/nexus/utils/", "viewer image"
+            images, "/ansys/nexus/utils/", "ansys/nexus/utils/", "viewer javascript support"
         )
         images = ["ANSYSViewer_min.js", "viewer-loader.js"]
-        self._download_static_files(images, "/ansys/nexus/", "ansys/nexus/", "viewer image")
+        self._download_static_files(
+            images, "/ansys/nexus/", "ansys/nexus/", "ansys-nexus-viewer js"
+        )
         images = [
             "jquery.contextMenu.min.css",
             "jquery.contextMenu.min.js",
@@ -204,7 +206,37 @@ class ReportDownloadHTML:
             images,
             "/ansys/nexus/novnc/vendor/jQuery-contextMenu/",
             "ansys/nexus/novnc/vendor/jQuery-contextMenu",
-            "viewer image",
+            "ansys-nexus-viewer vnc js",
+        )
+
+        image = [
+            "ArcballControls.js",
+            "DRACOLoader.js",
+            "GLTFLoader.js",
+            "OrbitControls.js",
+            "three.js",
+        ]
+        self._download_static_files(
+            image, "/ansys/nexus/threejs/", "ansys/nexus/threejs", "threejs core"
+        )
+
+        image = [
+            "draco_decoder.js",
+            "draco_decoder.wasm",
+            "draco_encoder.js",
+            "draco_wasm_wrapper.js",
+        ]
+        self._download_static_files(
+            image,
+            "/ansys/nexus/threejs/libs/draco/",
+            "ansys/nexus/threejs/libs/draco",
+            "threejs draco",
+        )
+        self._download_static_files(
+            image,
+            "/ansys/nexus/threejs/libs/draco/gltf/",
+            "ansys/nexus/threejs/libs/draco/gltf",
+            "threejs draco gltf",
         )
 
         # Fonts
@@ -215,7 +247,7 @@ class ReportDownloadHTML:
             "fa-solid-900.woff",
             "fa-solid-900.woff2",
         ]
-        self._download_static_files(fonts, "/static/website/webfonts/", "webfonts", "font")
+        self._download_static_files(fonts, "/static/website/webfonts/", "webfonts", "fonts")
 
     @staticmethod
     def _fix_viewer_component_paths(filename, data):
@@ -422,6 +454,7 @@ class ReportDownloadHTML:
         self._make_dir([self._directory, "webfonts"])
         self._make_dir([self._directory, "ansys", "nexus", "images"])
         self._make_dir([self._directory, "ansys", "nexus", "utils"])
+        self._make_dir([self._directory, "ansys", "nexus", "threejs", "libs", "draco", "gltf"])
         self._make_dir([self._directory, "ansys", "nexus", "novnc", "vendor", "jQuery-contextMenu"])
 
         # get the webpage html source


### PR DESCRIPTION
Offline HTML requires three.js to be downloaded for the AVZ renderer to work.
This is the other half of the fix for ADO bug # 963698