### PR TITLE
Force the requests version to avoid issues with docker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "pypng>=0.20220715.0",
     "python-dateutil>=2.8.0",
     "pytz>=2021.3",
-    "requests>=2.28.2",
+    "requests>=2.28.2,<2.32",
     "twine>=4.0.1",
     "urllib3<2.0.0",
     "Pillow>=9.3.0"


### PR DESCRIPTION
The new version v2.32.X of requests, changed the behavior in which the ``send`` command works - and other libraries like ``docker-py`` (which were overriding the behavior of underlying functions in the requests library) started failing.

Force the version to be < 2.32 while the other libraries get updated