### PR TITLE
Fix HTML downloads for Scenes

### DIFF
--- a/doc/source/gettingstarted/index.rst
+++ b/doc/source/gettingstarted/index.rst
@@ -42,7 +42,7 @@ latest ``pydynamicreporting`` package with this code:
    pip install virtualenv
    virtualenv venv  # create virtual environment. If on Windows, use virtualenv.exe venv
    source venv/bin/activate # If on Windows, use  .\venv\Scripts\activate
-   pip install -r requirements/dev.txt  # install dependencies
+   pip install .[dev]  # install dependencies
    make install-dev  # install pydynamicreporting in editable mode
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,7 @@ dev = [
     "Sphinx==7.2.6",
     "sphinx-copybutton==0.5.2",
     "sphinx-gallery==0.14.0",
+    "pre-commit>=3.3.3",
 ]
 
 [tool.pytest.ini_options]

--- a/src/ansys/dynamicreporting/core/utils/report_download_html.py
+++ b/src/ansys/dynamicreporting/core/utils/report_download_html.py
@@ -1,8 +1,6 @@
 import base64
 import os
 import os.path
-import pathlib
-import platform
 import re
 from typing import Optional
 import urllib.parse
@@ -327,6 +325,16 @@ class ReportDownloadHTML:
         self._collision_count += 1
         return f"{str(self._collision_count)}_{name}"
 
+    @staticmethod
+    def _is_scene_file(name: str) -> bool:
+        if name.upper().endswith(".AVZ"):
+            return True
+        if name.upper().endswith(".SCDOC"):
+            return True
+        if name.upper().endswith(".GLB"):
+            return True
+        return False
+
     def _get_file(self, path_plus_queries: str, pathname: str, inline: bool = False) -> str:
         if pathname in self._filemap:
             return self._filemap[pathname]
@@ -341,7 +349,9 @@ class ReportDownloadHTML:
             try:
                 tmp = resp.content
                 # 4/3 is roughly the expansion factor of base64 encoding (3bytes encode to 4)
-                if inline and self._should_use_data_uri(len(tmp) * (4.0 / 3.0)):
+                # Note: we will also inline any "scene" 3D file.  This can happen when processing
+                # a slider view "key_image" array.
+                if (inline or self._is_scene_file(pathname)) and self._should_use_data_uri(len(tmp) * (4.0 / 3.0)):
                     # convert to inline data domain URI. Prefix:  'data:application/octet-stream;base64,'
                     results = "data:application/octet-stream;base64," + base64.b64encode(
                         tmp

--- a/src/ansys/dynamicreporting/core/utils/report_download_html.py
+++ b/src/ansys/dynamicreporting/core/utils/report_download_html.py
@@ -351,7 +351,9 @@ class ReportDownloadHTML:
                 # 4/3 is roughly the expansion factor of base64 encoding (3bytes encode to 4)
                 # Note: we will also inline any "scene" 3D file.  This can happen when processing
                 # a slider view "key_image" array.
-                if (inline or self._is_scene_file(pathname)) and self._should_use_data_uri(len(tmp) * (4.0 / 3.0)):
+                if (inline or self._is_scene_file(pathname)) and self._should_use_data_uri(
+                    len(tmp) * (4.0 / 3.0)
+                ):
                     # convert to inline data domain URI. Prefix:  'data:application/octet-stream;base64,'
                     results = "data:application/octet-stream;base64," + base64.b64encode(
                         tmp

--- a/src/ansys/dynamicreporting/core/utils/report_remote_server.py
+++ b/src/ansys/dynamicreporting/core/utils/report_remote_server.py
@@ -874,9 +874,11 @@ class Server:
         from ansys.dynamicreporting.core.utils.report_download_html import ReportDownloadHTML
 
         url = self.build_url_with_query(report_guid, query)
-        _ansys_version = self._ansys_version
+        # ask the server for the Ansys version number. It will generally know it.
+        _ansys_version = self.get_api_version().get("ansys_version", self._ansys_version)
         if ansys_version:
             _ansys_version = ansys_version
+
         worker = ReportDownloadHTML(
             url=url,
             directory=directory_path,


### PR DESCRIPTION
Work around version issues by asking the server for its version number. Make sure to use inline for scenes in the key_images[] output.