### PR TITLE
Back off requests limitation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "pypng>=0.20220715.0",
     "python-dateutil>=2.8.0",
     "pytz>=2021.3",
-    "requests>=2.28.2,<2.32",
+    "requests>=2.32",
     "urllib3<2.0.0",
     "Pillow>=9.3.0"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,12 +40,12 @@ dependencies = [
     "filelock>=3.7.1",
     "numpy>=1.18.0,<2",
     "packaging>=21.0",
-    "docker>=6.1.0",
+    "docker>=7.1.0",
     "pypng>=0.20220715.0",
     "python-dateutil>=2.8.0",
     "pytz>=2021.3",
     "requests>=2.32",
-    "urllib3<2.0.0",
+    "urllib3<3.0.0",
     "Pillow>=9.3.0"
 ]
 
@@ -63,7 +63,7 @@ ci =  "https://github.com/ansys/pydynamicreporting/actions"
 
 [project.optional-dependencies]
 tests = [
-    "docker>=6.1.0",
+    "docker>=7.1.0",
     "numpy==1.25.1",
     "psutil==5.9.5",
     "pytest==7.4.2",
@@ -73,7 +73,7 @@ doc = [
     "ansys-sphinx-theme==0.11.2",
     "numpydoc==1.5.0",
     "pillow==10.0.1",
-    "docker>=6.1.0",
+    "docker>=7.1.0",
     "Sphinx==7.2.6",
     "sphinx-copybutton==0.5.2",
     "sphinx-gallery==0.14.0",
@@ -90,7 +90,7 @@ dev = [
     "numpydoc==1.5.0",
     "pillow==10.0.1",
     "psutil==5.9.5",
-    "docker>=6.1.0",
+    "docker>=7.1.0",
     "pytest==7.4.2",
     "pytest-cov==4.1.0",
     "Sphinx==7.2.6",


### PR DESCRIPTION
Back off limitation in the requests module version as the issue with other modules has been fixed.
See https://github.com/docker/docker-py/pull/3257