### PR TITLE
Added API methods for statistical analysis generator

### DIFF
--- a/src/ansys/dynamicreporting/core/utils/report_objects.py
+++ b/src/ansys/dynamicreporting/core/utils/report_objects.py
@@ -3473,8 +3473,8 @@ class statisticalREST(GeneratorREST):
     """
     Representation of a statistical analysis generator.
 
-    Defines getters and setters for analysis type, predictor variables,
-    response variables, and intercept.
+    Defines getters and setters for analysis type, predictor variables, response
+    variables, and intercept.
     """
 
     def __init__(self):
@@ -3493,7 +3493,7 @@ class statisticalREST(GeneratorREST):
     @property
     def predictor_variables(self):
         return self.get_property().get("predictor_variables")
-    
+
     @predictor_variables.setter
     def predictor_variables(self, value):
         props = self.get_property()
@@ -3503,7 +3503,7 @@ class statisticalREST(GeneratorREST):
     @property
     def response_variables(self):
         return self.get_property().get("response_variables")
-    
+
     @response_variables.setter
     def response_variables(self, value):
         props = self.get_property()
@@ -3513,7 +3513,7 @@ class statisticalREST(GeneratorREST):
     @property
     def intercept(self):
         return self.get_property().get("intercept")
-    
+
     @intercept.setter
     def intercept(self, value):
         props = self.get_property()

--- a/src/ansys/dynamicreporting/core/utils/report_objects.py
+++ b/src/ansys/dynamicreporting/core/utils/report_objects.py
@@ -3519,5 +3519,3 @@ class statisticalREST(GeneratorREST):
         props = self.get_property()
         props["intercept"] = value
         self.set_property(props)
-
-        

--- a/src/ansys/dynamicreporting/core/utils/report_objects.py
+++ b/src/ansys/dynamicreporting/core/utils/report_objects.py
@@ -3467,3 +3467,56 @@ class itemscomparisonREST(GeneratorREST):
         props = self.get_property()
         props["filters_table"] = input_table
         self.set_property(props)
+
+
+class statisticalREST(GeneratorREST):
+    """
+    Representation of a statistical analysis generator.
+
+    Defines getters and setters for analysis type, predictor variables,
+    response variables, and intercept.
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    @property
+    def analysis_type(self) -> str:
+        return self.get_property().get("analysis_type")
+
+    @analysis_type.setter
+    def analysis_type(self, value: str) -> None:
+        props = self.get_property()
+        props["analysis_type"] = value
+        self.set_property(props)
+
+    @property
+    def predictor_variables(self):
+        return self.get_property().get("predictor_variables")
+    
+    @predictor_variables.setter
+    def predictor_variables(self, value):
+        props = self.get_property()
+        props["predictor_variables"] = value
+        self.set_property(props)
+
+    @property
+    def response_variables(self):
+        return self.get_property().get("response_variables")
+    
+    @response_variables.setter
+    def response_variables(self, value):
+        props = self.get_property()
+        props["response_variables"] = value
+        self.set_property(props)
+
+    @property
+    def intercept(self):
+        return self.get_property().get("intercept")
+    
+    @intercept.setter
+    def intercept(self, value):
+        props = self.get_property()
+        props["intercept"] = value
+        self.set_property(props)
+        

--- a/src/ansys/dynamicreporting/core/utils/report_objects.py
+++ b/src/ansys/dynamicreporting/core/utils/report_objects.py
@@ -3519,4 +3519,5 @@ class statisticalREST(GeneratorREST):
         props = self.get_property()
         props["intercept"] = value
         self.set_property(props)
+
         

--- a/tests/test_report_objects.py
+++ b/tests/test_report_objects.py
@@ -1783,6 +1783,24 @@ def test_comparison_generator() -> bool:
     assert succ and succ_two
 
 
+@pytest.mark.ado_test
+def test_statistical_generator() -> bool:
+    a = ro.statisticalREST()
+    analysis_type = "linear_regression"
+    a.analysis_type = analysis_type
+    succ = a.analysis_type == analysis_type
+    predictor_variables = '["pressure", "temperature"]'
+    a.predictor_variables = predictor_variables
+    succ_two = a.predictor_variables == predictor_variables
+    response_variables = '["velocity", "misalignment"]'
+    a.response_variables = response_variables
+    succ_three = a.response_variables == response_variables
+    intercept = "1.0"
+    a.intercept = intercept
+    succ_four = a.intercept == intercept
+    assert succ and succ_two and succ_three and succ_four
+
+
 def test_item_payload(adr_service_query) -> bool:
     try:
         for i in adr_service_query.query():


### PR DESCRIPTION
Added API methods for statistical analysis generator in report_objects, defined getters and setters for analysis_type, predictor_variables, response_variables, and intercept. Added tests for API methods in test_statistical_generator()