### PR TITLE
Fix/same port n

### DIFF
--- a/src/ansys/dynamicreporting/core/adr_service.py
+++ b/src/ansys/dynamicreporting/core/adr_service.py
@@ -207,11 +207,7 @@ class Service:
             try:
                 # start the container and map specified host directory into the
                 # container.  The location in the container is always /host_directory/."
-                if report_utils.is_port_in_use(self._port):
-                    self.logger.warning(
-                        f"Warning: port {self._port} is already in use. Replace with a new port\n"
-                    )
-                    self._port = report_utils.find_unused_ports(count=1, start=self._port)[0]
+                self.__checkport__()
                 self._container.start(
                     host_directory=self._data_directory,
                     db_directory=self._db_directory,
@@ -378,7 +374,7 @@ class Service:
         username: str = "nexus",
         password: str = "cei",
         create_db: bool = False,
-        error_if_create_db_exists: bool = True,
+        error_if_create_db_exists: bool = False,
         exit_on_close: bool = False,
         delete_db: bool = False,
     ) -> str:
@@ -529,6 +525,7 @@ class Service:
         else:  # pragma: no cover
             # we're not using docker
             self.serverobj = report_remote_server.Server()
+            self.__checkport__()
             launched = False
             launch_kwargs = {
                 "directory": self._db_directory,
@@ -967,3 +964,21 @@ class Service:
         else:
             self.logger.warning("Invalid input: r_type needs to be name or report")
         return r_list
+
+    def __checkport__(self):
+        """
+        Internal method to check if a port is already being used and if yes, change
+        self._port to an other free port.
+
+        Parameters
+        ----------
+        None
+        Returns
+        -------
+        None
+        """
+        if report_utils.is_port_in_use(self._port):
+            self.logger.warning(
+                f"Warning: port {self._port} is already in use. Replace with a new port\n"
+            )
+            self._port = report_utils.find_unused_ports(count=1, start=self._port)[0]

--- a/src/ansys/dynamicreporting/core/adr_service.py
+++ b/src/ansys/dynamicreporting/core/adr_service.py
@@ -207,7 +207,11 @@ class Service:
             try:
                 # start the container and map specified host directory into the
                 # container.  The location in the container is always /host_directory/."
-                self.__checkport__()
+                if report_utils.is_port_in_use(self._port):
+                    self.logger.warning(
+                        f"Warning: port {self._port} is already in use. Replace with a new port\n"
+                    )
+                    self._port = report_utils.find_unused_ports(count=1, start=self._port)[0]
                 self._container.start(
                     host_directory=self._data_directory,
                     db_directory=self._db_directory,
@@ -374,7 +378,7 @@ class Service:
         username: str = "nexus",
         password: str = "cei",
         create_db: bool = False,
-        error_if_create_db_exists: bool = False,
+        error_if_create_db_exists: bool = True,
         exit_on_close: bool = False,
         delete_db: bool = False,
     ) -> str:
@@ -525,7 +529,6 @@ class Service:
         else:  # pragma: no cover
             # we're not using docker
             self.serverobj = report_remote_server.Server()
-            self.__checkport__()
             launched = False
             launch_kwargs = {
                 "directory": self._db_directory,
@@ -964,22 +967,3 @@ class Service:
         else:
             self.logger.warning("Invalid input: r_type needs to be name or report")
         return r_list
-
-    def __checkport__(self):
-        """
-        Internal method to check if a port is already being used and if yes, change
-        self._port to an other free port.
-
-        Parameters
-        ----------
-        None
-
-        Returns
-        -------
-        None
-        """
-        if report_utils.is_port_in_use(self._port):
-            self.logger.warning(
-                f"Warning: port {self._port} is already in use. Replace with a new port\n"
-            )
-            self._port = report_utils.find_unused_ports(count=1, start=self._port)[0]

--- a/test_cleanup.py
+++ b/test_cleanup.py
@@ -16,7 +16,8 @@ dir_list.extend(
         "tests/test_data/webfonts/",
         "htmltest/",
         "htmltest_again/",
-        "sameport/" "sameport_again/",
+        "sameport/"
+        "sameport_again/"
     ]
 )
 dir_list.append("tests/test_data/create_delete/")

--- a/test_cleanup.py
+++ b/test_cleanup.py
@@ -16,8 +16,6 @@ dir_list.extend(
         "tests/test_data/webfonts/",
         "htmltest/",
         "htmltest_again/",
-        "sameport/"
-        "sameport_again/"
     ]
 )
 dir_list.append("tests/test_data/create_delete/")

--- a/test_cleanup.py
+++ b/test_cleanup.py
@@ -16,14 +16,14 @@ dir_list.extend(
         "tests/test_data/webfonts/",
         "htmltest/",
         "htmltest_again/",
-        "sameport/",
-        "sameport_again",
     ]
 )
 dir_list.append("tests/test_data/create_delete/")
 dir_list.append("tests/test_data/create_twice/")
 dir_list.append("tests/test_data/newcopytemp/")
 dir_list.append("tests/test_data/newcopy/")
+dir_list.append("tests/test_data/sameport/")
+dir_list.append("tests/test_data/sameport_again/")
 for i_dir in dir_list:
     try:
         shutil.rmtree(i_dir)

--- a/test_cleanup.py
+++ b/test_cleanup.py
@@ -17,7 +17,7 @@ dir_list.extend(
         "htmltest/",
         "htmltest_again/",
         "sameport/",
-        "sameport_again"
+        "sameport_again",
     ]
 )
 dir_list.append("tests/test_data/create_delete/")

--- a/test_cleanup.py
+++ b/test_cleanup.py
@@ -16,6 +16,8 @@ dir_list.extend(
         "tests/test_data/webfonts/",
         "htmltest/",
         "htmltest_again/",
+        "sameport/",
+        "sameport_again"
     ]
 )
 dir_list.append("tests/test_data/create_delete/")

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -379,15 +379,3 @@ def test_docker_unit() -> bool:
     except AttributeError as e:
         succ_five = "has no attribute" in str(e)
     assert succ and succ_two and succ_three and succ_four and succ_five
-
-
-@pytest.mark.ado_test
-def test_same_port(request) -> bool:
-    logfile = join(request.fspath.dirname, "outfile_10.txt")
-    a = Service(logfile=logfile, db_directory="sameport")
-    _ = a.start(create_db=True)
-    b = Service(logfile=logfile, db_directory="sameport_again", port = a._port)
-    _ = b.start(create_db=True)
-    a.stop()
-    b.stop()
-    assert a._port != b._port

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -379,3 +379,16 @@ def test_docker_unit() -> bool:
     except AttributeError as e:
         succ_five = "has no attribute" in str(e)
     assert succ and succ_two and succ_three and succ_four and succ_five
+
+
+@pytest.mark.ado_test
+def test_same_port(request) -> bool:
+    logfile = join(request.fspath.dirname, "outfile_10.txt")
+    a = Service(logfile=logfile, db_directory="sameport")
+    _ = a.start(create_db=True)
+    b = Service(logfile=logfile, db_directory="sameport_again", port=a._port)
+    _ = b.start(create_db=True)
+    a.stop()
+    b.stop()
+    assert a._port != b._port
+    

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -225,7 +225,7 @@ def test_create_on_existing(request, get_exec) -> bool:
         )
     success = False
     try:
-        _ = tmp_adr.start(create_db=True)
+        _ = tmp_adr.start(create_db=True, error_if_create_db_exists=True)
     except CannotCreateDatabaseError:
         success = True
     assert success
@@ -384,9 +384,11 @@ def test_docker_unit() -> bool:
 @pytest.mark.ado_test
 def test_same_port(request) -> bool:
     logfile = join(request.fspath.dirname, "outfile_10.txt")
-    a = Service(logfile=logfile, db_directory="sameport")
+    db_dir = join(join(request.fspath.dirname, "test_data"), "sameport")
+    db_dir_again = join(join(request.fspath.dirname, "test_data"), "sameport_again")
+    a = Service(logfile=logfile, db_directory=db_dir)
     _ = a.start(create_db=True)
-    b = Service(logfile=logfile, db_directory="sameport_again", port=a._port)
+    b = Service(logfile=logfile, db_directory=db_dir_again, port=a._port)
     _ = b.start(create_db=True)
     a.stop()
     b.stop()

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -382,13 +382,27 @@ def test_docker_unit() -> bool:
 
 
 @pytest.mark.ado_test
-def test_same_port(request) -> bool:
+def test_same_port(request, get_exec) -> bool:
     logfile = join(request.fspath.dirname, "outfile_10.txt")
     db_dir = join(join(request.fspath.dirname, "test_data"), "sameport")
     db_dir_again = join(join(request.fspath.dirname, "test_data"), "sameport_again")
-    a = Service(logfile=logfile, db_directory=db_dir)
+    if get_exec != "":
+        a = Service(ansys_installation=get_exec, logfile=logfile, db_directory=db_dir)
+        b = Service(
+            ansys_installation=get_exec, logfile=logfile, db_directory=db_dir_again, port=a._port
+        )
+    else:
+        cleanup_docker(request)
+        a = Service(
+            ansys_installation="docker", docker_image=DOCKER_DEV_REPO_URL, db_directory=db_dir
+        )
+        b = Service(
+            ansys_installation="docker",
+            docker_image=DOCKER_DEV_REPO_URL,
+            db_directory=db_dir_again,
+            port=a._port,
+        )
     _ = a.start(create_db=True)
-    b = Service(logfile=logfile, db_directory=db_dir_again, port=a._port)
     _ = b.start(create_db=True)
     a.stop()
     b.stop()

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -386,7 +386,7 @@ def test_same_port(request) -> bool:
     logfile = join(request.fspath.dirname, "outfile_10.txt")
     a = Service(logfile=logfile, db_directory="sameport")
     _ = a.start(create_db=True)
-    b = Service(logfile=logfile, db_directory="sameport_again", port=a._port)
+    b = Service(logfile=logfile, db_directory="sameport_again", port = a._port)
     _ = b.start(create_db=True)
     a.stop()
     b.stop()

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -391,4 +391,3 @@ def test_same_port(request) -> bool:
     a.stop()
     b.stop()
     assert a._port != b._port
-    


### PR DESCRIPTION
By mistake I pushed directly into main. So here a "fake" PR to get you to review the changes that already made it into main.
The problem was that if you have 2 services with the same port number and you try to start them, the first would start and the second would instead connect to the first without any error.
Now the second will find a new port and start on the new port.

Main change and new test associate with it here:
https://github.com/ansys/pydynamicreporting/commit/245eb0b440ede11c4b11fd2cf871c62cbdd35d09
