### PR TITLE
Natural sorting changes and minor doc updates

### DIFF
--- a/doc/source/class_documentation.rst
+++ b/doc/source/class_documentation.rst
@@ -2,7 +2,7 @@
 API reference
 *************
 
-Ansys Dynamic Reporting contains a low-level API that allows the user to access
+Ansys Dynamic Reporting contains a low-level API that allows you to access
 all the available features and properties in full detail. While this low-level
 API is very powerful, it can also be quite complex to use and it requires a
 steep learning curve. For a comprehensive description of this API, see

--- a/doc/source/gettingstarted/index.rst
+++ b/doc/source/gettingstarted/index.rst
@@ -15,7 +15,7 @@ To get a copy of Ansys, visit the `Ansys <https://www.ansys.com/>`_ website.
    is installed separately, and can be found in the Fluids section of the
    Ansys installer. Please also note that in all versions, Ansys Dynamic Reporting
    is automatically installed if one of the following Ansys products is
-   installed: EnSight, Forte, Fluent, Polyflow, Icepack.
+   installed: EnSight, Forte, Fluent, Polyflow, or Icepack.
 
 
 

--- a/doc/source/lowlevelapi/TemplateObjects.rst
+++ b/doc/source/lowlevelapi/TemplateObjects.rst
@@ -656,6 +656,9 @@ The accepted sorted orders are:
 -  'numeric_up': corresponds to Numeric sort up
 -  'numeric_down': corresponds to Numeric sort down
 -  'none': corresponds to No sorting
+-  'natural_up': corresponds to Natural sort up
+-  'natural_down': corresponds to Natural sort down
+-  'none': corresponds to No sorting
 
 An example of output of this function is: ['tag1|text_up',
 'tag2|numeric_down', 'tag3|none'] where the slider is sorted by "tag1"


### PR DESCRIPTION
Changed natural sorting text per Marina's request. Also a few minor doc edits.

Get the Selected tags and sort to map to sliders. This function returns a list where each element corresponds to one tag and its sorting order. The accepted sorted orders are:
•	'text_up': corresponds to Text sort up
•	'text_down': corresponds to Text sort down
•	'numeric_up': corresponds to Numeric sort up
•	'numeric_down': corresponds to Numeric sort down
•	'none': corresponds to No sorting


To be:

Get the Selected tags and sort to map to sliders. This function returns a list where each element corresponds to one tag and its sorting order. The accepted sorted orders are:
•	'text_up': corresponds to Text sort up
•	'text_down': corresponds to Text sort down
•	'numeric_up': corresponds to Numeric sort up
•	'numeric_down': corresponds to Numeric sort down
•	'natural_up': corresponds to Natural sort up
•	'natural_down': corresponds to Natural sort down
•	'none': corresponds to No sorting
