### PR TITLE
Add OBJLoader.js to offline html

### DIFF
--- a/src/ansys/dynamicreporting/core/utils/report_download_html.py
+++ b/src/ansys/dynamicreporting/core/utils/report_download_html.py
@@ -235,6 +235,7 @@ class ReportDownloadHTML:
             "DRACOLoader.js",
             "GLTFLoader.js",
             "OrbitControls.js",
+            "OBJLoader.js",
             "three.js",
             "VRButton.js",
         ]


### PR DESCRIPTION
Add the missing `OBJLoader.js` file during the process of offline html export.