### PR TITLE
Change documentation links to ansys open documentation

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -16,6 +16,37 @@ project = "ansys-dynamicreporting-core"
 copyright = f"(c) {datetime.now().year} ANSYS, Inc. All rights reserved"
 author = "Ansys Inc."
 release = version = __version__
+__ansys_version__ = 251
+
+rst_prolog = f"""
+.. _here: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v{__ansys_version__}/en/adr_ug/adr_ug_layout_templates.html
+.. _link: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v{__ansys_version__}/en/adr_ug/adr_ug_query_expressions.html
+.. _Columns: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v{__ansys_version__}/en/adr_ug/adr_ug_layout_columns.html
+.. _Panel: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v{__ansys_version__}/en/adr_ug/adr_ug_layout_panel.html
+.. _Boxes: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v{__ansys_version__}/en/adr_ug/adr_ug_layout_boxes.html
+.. _Tabs: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v{__ansys_version__}/en/adr_ug/adr_ug_layout_tabs.html
+.. _Carousel: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v{__ansys_version__}/en/adr_ug/adr_ug_layout_carousel.html
+.. _Slider: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v{__ansys_version__}/en/adr_ug/adr_ug_layout_slider.html
+.. _Page Footer: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v{__ansys_version__}/en/adr_ug/adr_ug_layout_page_footer.html
+.. _Page Header: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v{__ansys_version__}/en/adr_ug/adr_ug_layout_page_header.html
+.. _Iterator: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v{__ansys_version__}/en/adr_ug/adr_ug_layout_iterator.html
+.. _Tag to Properties: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v{__ansys_version__}/en/adr_ug/adr_ug_layout_tag_properties.html
+.. _Table of Contents: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v{__ansys_version__}/en/adr_ug/adr_ug_layout_table_of_contents.html
+.. _Link Report: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v{__ansys_version__}/en/adr_ug/adr_ug_layout_linked_report.html
+.. _Table Merge: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v{__ansys_version__}/en/adr_ug/adr_ug_generator_table_merge.html
+.. _Table Reduction: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v{__ansys_version__}/en/adr_ug/adr_ug_generator_table_reduction.html
+.. _Table Row/Column Filter: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v{__ansys_version__}/en/adr_ug/adr_ug_generator_table_row_column_filter.html
+.. _Table Value Filter: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v{__ansys_version__}/en/adr_ug/adr_ug_generator_table_value_filter.html
+.. _Table Row/Column Sort: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v{__ansys_version__}/en/adr_ug/adr_ug_generator_table_row_column_sort.html
+.. _SQL Query: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v{__ansys_version__}/en/adr_ug/adr_ug_generator_sql_query.html
+.. _Tree Merge: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v{__ansys_version__}/en/adr_ug/adr_ug_generator_tree_merge.html
+.. _Userdefined: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v{__ansys_version__}/en/adr_ug/adr_ug_layout_user_defined_block.html
+.. _Generator templates: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v{__ansys_version__}/en/adr_ug/adr_ug_generator_templates.html
+.. _Statistical Analysis: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v{__ansys_version__}/en/adr_ug/ad_ug_generator_statistical_analysis.html
+.. _this: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v{__ansys_version__}/en/adr_ug/adr_ug_data_item_table.html
+.. _Query Expressions: <https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v{__ansys_version__}/en/adr_ug/adr_ug_query_expressions.html>
+
+"""
 
 # Select desired logo, theme, and declare the html title
 html_logo = pyansys_logo_black

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -19,8 +19,7 @@ release = version = __version__
 __ansys_version__ = 251
 
 rst_prolog = f"""
-.. _here: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v{__ansys_version__}/en/adr_ug/adr_ug_layout_templates.html
-.. _link: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v{__ansys_version__}/en/adr_ug/adr_ug_query_expressions.html
+.. _Layout Templates: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v{__ansys_version__}/en/adr_ug/adr_ug_layout_templates.html
 .. _Columns: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v{__ansys_version__}/en/adr_ug/adr_ug_layout_columns.html
 .. _Panel: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v{__ansys_version__}/en/adr_ug/adr_ug_layout_panel.html
 .. _Boxes: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v{__ansys_version__}/en/adr_ug/adr_ug_layout_boxes.html
@@ -43,7 +42,7 @@ rst_prolog = f"""
 .. _Userdefined: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v{__ansys_version__}/en/adr_ug/adr_ug_layout_user_defined_block.html
 .. _Generator templates: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v{__ansys_version__}/en/adr_ug/adr_ug_generator_templates.html
 .. _Statistical Analysis: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v{__ansys_version__}/en/adr_ug/ad_ug_generator_statistical_analysis.html
-.. _this: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v{__ansys_version__}/en/adr_ug/adr_ug_data_item_table.html
+.. _Table: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v{__ansys_version__}/en/adr_ug/adr_ug_data_item_table.html
 .. _Query Expressions: <https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v{__ansys_version__}/en/adr_ug/adr_ug_query_expressions.html>
 
 """

--- a/doc/source/gettingstarted/index.rst
+++ b/doc/source/gettingstarted/index.rst
@@ -130,7 +130,7 @@ in the :func:`connect<ansys.dynamicreporting.core.Service.connect>` method:
    see the Ansys Dynamic Reporting `documentation`_.
 
 
-.. _documentation: https://nexusdemo.ensight.com/docs/is/html/Nexus.html
+.. _documentation: https://ansysproducthelpqa.win.ansys.com/public/account/secured?returnurl=Views/Secured/prod_page.html?pn=Ansys%20Dynamic%20Reporting&prodver=25.2&lang=en
 
 Now, assume that you do not have a running Ansys Dynamic Reporting service
 accessible to you and that you must start one. You can use this simple

--- a/doc/source/gettingstarted/index.rst
+++ b/doc/source/gettingstarted/index.rst
@@ -130,7 +130,8 @@ in the :func:`connect<ansys.dynamicreporting.core.Service.connect>` method:
    see the Ansys Dynamic Reporting `documentation`_.
 
 
-.. _documentation: https://ansysproducthelpqa.win.ansys.com/public/account/secured?returnurl=Views/Secured/prod_page.html?pn=Ansys%20Dynamic%20Reporting&prodver=25.2&lang=en
+.. _documentation: https://ansyshelp.ansys.com/public/account/secured?returnurl=/Views/Secured/prod_page.html?pn=Ansys%20Dynamic%20Reporting&pid=ansdynrep&lang=en
+
 
 Now, assume that you do not have a running Ansys Dynamic Reporting service
 accessible to you and that you must start one. You can use this simple

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -11,7 +11,7 @@ PyDynamicReporting
    examples/index
    contributing
 
-.. _Nexus: https://nexusdemo.ensight.com/docs/html/Nexus.html
+.. _Nexus: https://ansysproducthelpqa.win.ansys.com/public/account/secured?returnurl=Views/Secured/prod_page.html?pn=Ansys%20Dynamic%20Reporting&prodver=25.2&lang=en
 
 Introduction
 ------------

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -11,7 +11,7 @@ PyDynamicReporting
    examples/index
    contributing
 
-.. _Nexus: https://ansysproducthelpqa.win.ansys.com/public/account/secured?returnurl=Views/Secured/prod_page.html?pn=Ansys%20Dynamic%20Reporting&prodver=25.2&lang=en
+.. _Nexus: https://ansyshelp.ansys.com/public/account/secured?returnurl=/Views/Secured/prod_page.html?pn=Ansys%20Dynamic%20Reporting&pid=ansdynrep&lang=en
 
 Introduction
 ------------

--- a/doc/source/lowlevelapi/DataItemObject.rst
+++ b/doc/source/lowlevelapi/DataItemObject.rst
@@ -228,7 +228,8 @@ Many more table properties exist and can be set as the default values
 for a table by setting same-named keys in the dictionary. The properties
 are documented in the item properties section at `this`_ page.
 
-.. _this: https://ansysproducthelpqa.win.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_data_item_table.html
+.. _this: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_data_item_table.html
+
 
 A short-cut APIs exists for a common case:
 

--- a/doc/source/lowlevelapi/DataItemObject.rst
+++ b/doc/source/lowlevelapi/DataItemObject.rst
@@ -228,9 +228,6 @@ Many more table properties exist and can be set as the default values
 for a table by setting same-named keys in the dictionary. The properties
 are documented in the item properties section at `this`_ page.
 
-.. _this: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_data_item_table.html
-
-
 A short-cut APIs exists for a common case:
 
 .. code-block:: python

--- a/doc/source/lowlevelapi/DataItemObject.rst
+++ b/doc/source/lowlevelapi/DataItemObject.rst
@@ -226,9 +226,10 @@ plotter attributes. One example might be:
 
 Many more table properties exist and can be set as the default values
 for a table by setting same-named keys in the dictionary. The properties
-are documented in the item properties section at `this`_ page.
+are documented in the item properties section described in `Table`_
+in the documentation for Ansys Dynamic Reporting.
 
-A short-cut APIs exists for a common case:
+A shortcut API exists for a common case:
 
 .. code-block:: python
 

--- a/doc/source/lowlevelapi/DataItemObject.rst
+++ b/doc/source/lowlevelapi/DataItemObject.rst
@@ -228,7 +228,7 @@ Many more table properties exist and can be set as the default values
 for a table by setting same-named keys in the dictionary. The properties
 are documented in the item properties section at `this`_ page.
 
-.. _this: https://nexusdemo.ensight.com/docs/en/html/Nexus.html?TableItem.html
+.. _this: https://ansysproducthelpqa.win.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_data_item_table.html
 
 A short-cut APIs exists for a common case:
 

--- a/doc/source/lowlevelapi/TemplateObjects.rst
+++ b/doc/source/lowlevelapi/TemplateObjects.rst
@@ -3,30 +3,54 @@
 Template Objects
 ================
 
-.. _here: https://ansysproducthelpqa.win.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_layout_templates.html
-.. _link: https://ansysproducthelpqa.win.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_query_expressions.html
-.. _Columns: https://ansysproducthelpqa.win.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_layout_columns.html
-.. _Panel: https://ansysproducthelpqa.win.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_layout_panel.html
-.. _Boxes: https://ansysproducthelpqa.win.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_layout_boxes.html
-.. _Tabs: https://ansysproducthelpqa.win.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_layout_tabs.html
-.. _Carousel: https://ansysproducthelpqa.win.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_layout_carousel.html
-.. _Slider: https://ansysproducthelpqa.win.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_layout_slider.html
-.. _Page Footer: https://ansysproducthelpqa.win.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_layout_page_footer.html
-.. _Page Header: https://ansysproducthelpqa.win.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_layout_page_header.html
-.. _Iterator: https://ansysproducthelpqa.win.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_layout_iterator.html
-.. _Tag to Properties: https://ansysproducthelpqa.win.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_layout_tag_properties.html
-.. _Table of Contents: https://ansysproducthelpqa.win.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_layout_table_of_contents.html
-.. _Link Report: https://ansysproducthelpqa.win.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_layout_linked_report.html
-.. _Table Merge: https://ansysproducthelpqa.win.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_generator_table_merge.html
-.. _Table Reduction: https://ansysproducthelpqa.win.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_generator_table_reduction.html
-.. _Table Row/Column Filter: https://ansysproducthelpqa.win.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_generator_table_row_column_filter.html
-.. _Table Value Filter: https://ansysproducthelpqa.win.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_generator_table_value_filter.html
-.. _Table Row/Column Sort: https://ansysproducthelpqa.win.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_generator_table_row_column_sort.html
-.. _SQL Query: https://ansysproducthelpqa.win.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_generator_sql_query.html
-.. _Tree Merge: https://ansysproducthelpqa.win.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_generator_tree_merge.html
-.. _Userdefined: https://ansysproducthelpqa.win.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_layout_user_defined_block.html
-.. _Generator templates: https://ansysproducthelpqa.win.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_generator_templates.html
-.. _Statistical Analysis: https://ansysproducthelpqa.win.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/ad_ug_generator_statistical_analysis.html
+.. _here: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_layout_templates.html
+
+.. _link: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_query_expressions.html
+
+.. _Columns: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_layout_columns.html
+
+.. _Panel: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_layout_panel.html
+
+.. _Boxes: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_layout_boxes.html
+
+.. _Tabs: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_layout_tabs.html
+
+.. _Carousel: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_layout_carousel.html
+
+.. _Slider: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_layout_slider.html
+
+.. _Page Footer: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_layout_page_footer.html
+
+.. _Page Header: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_layout_page_header.html
+
+.. _Iterator: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_layout_iterator.html
+
+.. _Tag to Properties: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_layout_tag_properties.html
+
+.. _Table of Contents: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_layout_table_of_contents.html
+
+.. _Link Report: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_layout_linked_report.html
+
+.. _Table Merge: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_generator_table_merge.html
+
+.. _Table Reduction: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_generator_table_reduction.html
+
+.. _Table Row/Column Filter: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_generator_table_row_column_filter.html
+
+.. _Table Value Filter: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_generator_table_value_filter.html
+
+.. _Table Row/Column Sort: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_generator_table_row_column_sort.html
+
+.. _SQL Query: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_generator_sql_query.html
+
+.. _Tree Merge: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_generator_tree_merge.html
+
+.. _Userdefined: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_layout_user_defined_block.html
+
+.. _Generator templates: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_generator_templates.html
+
+.. _Statistical Analysis: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/ad_ug_generator_statistical_analysis.html
+
 
 
 report_objects.TemplateREST object

--- a/doc/source/lowlevelapi/TemplateObjects.rst
+++ b/doc/source/lowlevelapi/TemplateObjects.rst
@@ -3,55 +3,6 @@
 Template Objects
 ================
 
-.. _here: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_layout_templates.html
-
-.. _link: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_query_expressions.html
-
-.. _Columns: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_layout_columns.html
-
-.. _Panel: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_layout_panel.html
-
-.. _Boxes: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_layout_boxes.html
-
-.. _Tabs: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_layout_tabs.html
-
-.. _Carousel: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_layout_carousel.html
-
-.. _Slider: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_layout_slider.html
-
-.. _Page Footer: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_layout_page_footer.html
-
-.. _Page Header: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_layout_page_header.html
-
-.. _Iterator: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_layout_iterator.html
-
-.. _Tag to Properties: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_layout_tag_properties.html
-
-.. _Table of Contents: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_layout_table_of_contents.html
-
-.. _Link Report: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_layout_linked_report.html
-
-.. _Table Merge: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_generator_table_merge.html
-
-.. _Table Reduction: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_generator_table_reduction.html
-
-.. _Table Row/Column Filter: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_generator_table_row_column_filter.html
-
-.. _Table Value Filter: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_generator_table_value_filter.html
-
-.. _Table Row/Column Sort: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_generator_table_row_column_sort.html
-
-.. _SQL Query: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_generator_sql_query.html
-
-.. _Tree Merge: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_generator_tree_merge.html
-
-.. _Userdefined: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_layout_user_defined_block.html
-
-.. _Generator templates: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_generator_templates.html
-
-.. _Statistical Analysis: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/ad_ug_generator_statistical_analysis.html
-
-
 
 report_objects.TemplateREST object
 ----------------------------------

--- a/doc/source/lowlevelapi/TemplateObjects.rst
+++ b/doc/source/lowlevelapi/TemplateObjects.rst
@@ -90,20 +90,20 @@ interested in for each field for sake of clarity and usability.
 **template.get_property()**
 
 Get the properties of the template as a dictionary. A general
-description of what properties are for a template can be found
-`here`_.
+description of what properties are for a template can be found in
+`Layout Templates`_ in the documentation of Ansys Dynamic Reporting.
 
 **template.set_property(property={})**
 
 Set the properties of the template. Input needs to be a dictionary. A
-general description of what properties are for a template can be found
-`here`_.
+general description of what properties are for a template can be found in
+`Layout Templates`_ in the documentation of Ansys Dynamic Reporting.
 
 **template.add_property(property={})**
 
 Add the properties of the template. Input needs to be a dictionary. A
-general description of what properties are for a template can be found
-`here`_.
+general description of what properties are for a template can be found in
+`Layout Templates`_ in the documentation of Ansys Dynamic Reporting.
 
 **template.get_sort_fields()**
 
@@ -114,7 +114,8 @@ Get the sorting filter of the template.
 Set the sorting filter of the template. This function takes a list as
 input. The list is generated with '+' for increasing, '-' for
 decreasing, followed by the property to sort by, with the same strings
-as reported at this `link`_. Example: setting the sort
+as reported in `Query Expressions`_ in the documentation for Ansys Dynamic
+Reporting. Example: setting the sort
 fields to be by increasing item date and decreasing by item name
 becomes: ['+i_date', '-i_name']
 
@@ -123,7 +124,8 @@ becomes: ['+i_date', '-i_name']
 Add elements to the sorting filter of the template. This function takes
 a list as input. The list is generated with '+' for increasing, '-' for
 decreasing, followed by the property to sort by, with the same strings
-as reported `link`_. Example: setting the sort
+as reported `Query Expressions`_ in the documentation for Ansys Dynamic
+Reporting. Example: setting the sort
 fields to be by increasing item date and decreasing by item name
 becomes: ['+i_date', '-i_name']
 
@@ -168,19 +170,20 @@ string.
 **template.get_filter()**
 
 Get the item filter of the template. The item filter is encoded as a
-string using the format explained `link`_.
+string using the format explained in `Query Expressions`_
+in the documentation for Ansys Dynamic Reporting.
 
 **template.set_filter(filter_str='')**
 
 Sets the item filter of the template. Takes as input a string. The item
-filter is encoded as a string using the format explained
-`link`_.
+filter is encoded as a string using the format explained in
+`Query Expressions`_ in the documentation for Ansys Dynamic Reporting.
 
 **template.add_filter(filter_str='')**
 
 Add filters to the item filter of the template. Takes as input a string.
-The item filter is encoded as a string using the format explained
-`link`_.
+The item filter is encoded as a string using the format explained in
+`Query Expressions`_ in the documentation for Ansys Dynamic Reporting.
 
 **template.get_filter_mode()**
 
@@ -314,7 +317,8 @@ LayoutREST class
 Inherits from TemplateREST
 
 Class that groups all the common attributes among Layout templates
-(for reference, see `here`_). Its specific methods are:
+(for reference, see `Layout Templates`_ in the documentation
+for Ansys Dynamic Reporting). Its specific methods are:
 
 **template.get_column_count()**
 

--- a/doc/source/lowlevelapi/TemplateObjects.rst
+++ b/doc/source/lowlevelapi/TemplateObjects.rst
@@ -3,30 +3,30 @@
 Template Objects
 ================
 
-.. _here: https://s3.amazonaws.com/www3.ensight.com/nexus_docs/nexus_sphinx/is/LayoutTemplates.html
-.. _link: https://s3.amazonaws.com/www3.ensight.com/nexus_docs/nexus_sphinx/is/QueryExpressions.html
-.. _Columns: https://s3.amazonaws.com/www3.ensight.com/nexus_docs/nexus_sphinx/is/Columns.html
-.. _Panel: https://s3.amazonaws.com/www3.ensight.com/nexus_docs/nexus_sphinx/is/Panel.html
-.. _Boxes: https://s3.amazonaws.com/www3.ensight.com/nexus_docs/nexus_sphinx/is/Boxes.html
-.. _Tabs: https://s3.amazonaws.com/www3.ensight.com/nexus_docs/nexus_sphinx/is/Tabs.html
-.. _Carousel: https://s3.amazonaws.com/www3.ensight.com/nexus_docs/nexus_sphinx/is/Carousel.html
-.. _Slider: https://s3.amazonaws.com/www3.ensight.com/nexus_docs/nexus_sphinx/is/Slider.html
-.. _Page Footer: https://s3.amazonaws.com/www3.ensight.com/nexus_docs/nexus_sphinx/is/PageFooter.html
-.. _Page Header: https://s3.amazonaws.com/www3.ensight.com/nexus_docs/nexus_sphinx/is/PageHeader.html
-.. _Iterator: https://s3.amazonaws.com/www3.ensight.com/nexus_docs/nexus_sphinx/is/Iterator.html
-.. _Tag to Properties: https://s3.amazonaws.com/www3.ensight.com/nexus_docs/nexus_sphinx/is/TagProperties.html
-.. _Table of Contents: https://s3.amazonaws.com/www3.ensight.com/nexus_docs/nexus_sphinx/is/TableofContents.html
-.. _Link Report: https://s3.amazonaws.com/www3.ensight.com/nexus_docs/nexus_sphinx/is/LinkedReport.html
-.. _Table Merge: https://s3.amazonaws.com/www3.ensight.com/nexus_docs/nexus_sphinx/is/TableMerge.html
-.. _Table Reduction: https://s3.amazonaws.com/www3.ensight.com/nexus_docs/nexus_sphinx/is/TableReduction.html
-.. _Table Row/Column Filter: https://s3.amazonaws.com/www3.ensight.com/nexus_docs/nexus_sphinx/is/TableRowColumnFilter.html
-.. _Table Value Filter: https://s3.amazonaws.com/www3.ensight.com/nexus_docs/nexus_sphinx/is/TableValueFilter.html
-.. _Table Row/Column Sort: https://s3.amazonaws.com/www3.ensight.com/nexus_docs/nexus_sphinx/is/TableRowColumnSort.html
-.. _SQL Query: https://s3.amazonaws.com/www3.ensight.com/nexus_docs/nexus_sphinx/is/SQLQuery.html
-.. _Tree Merge: https://s3.amazonaws.com/www3.ensight.com/nexus_docs/nexus_sphinx/is/TreeMerge.html
-.. _Userdefined: https://s3.amazonaws.com/www3.ensight.com/nexus_docs/nexus_sphinx/is/Userdefined.html
-.. _Generator templates: https://s3.amazonaws.com/www3.ensight.com/nexus_docs/nexus_sphinx/is/GeneratorTemplates.html
-.. _Statistical Analysis: https://ansysproducthelpqa.win.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v251/en/adr_ug/ad_ug_generator_statistical_analysis.html
+.. _here: https://ansysproducthelpqa.win.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_layout_templates.html
+.. _link: https://ansysproducthelpqa.win.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_query_expressions.html
+.. _Columns: https://ansysproducthelpqa.win.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_layout_columns.html
+.. _Panel: https://ansysproducthelpqa.win.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_layout_panel.html
+.. _Boxes: https://ansysproducthelpqa.win.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_layout_boxes.html
+.. _Tabs: https://ansysproducthelpqa.win.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_layout_tabs.html
+.. _Carousel: https://ansysproducthelpqa.win.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_layout_carousel.html
+.. _Slider: https://ansysproducthelpqa.win.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_layout_slider.html
+.. _Page Footer: https://ansysproducthelpqa.win.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_layout_page_footer.html
+.. _Page Header: https://ansysproducthelpqa.win.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_layout_page_header.html
+.. _Iterator: https://ansysproducthelpqa.win.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_layout_iterator.html
+.. _Tag to Properties: https://ansysproducthelpqa.win.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_layout_tag_properties.html
+.. _Table of Contents: https://ansysproducthelpqa.win.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_layout_table_of_contents.html
+.. _Link Report: https://ansysproducthelpqa.win.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_layout_linked_report.html
+.. _Table Merge: https://ansysproducthelpqa.win.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_generator_table_merge.html
+.. _Table Reduction: https://ansysproducthelpqa.win.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_generator_table_reduction.html
+.. _Table Row/Column Filter: https://ansysproducthelpqa.win.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_generator_table_row_column_filter.html
+.. _Table Value Filter: https://ansysproducthelpqa.win.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_generator_table_value_filter.html
+.. _Table Row/Column Sort: https://ansysproducthelpqa.win.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_generator_table_row_column_sort.html
+.. _SQL Query: https://ansysproducthelpqa.win.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_generator_sql_query.html
+.. _Tree Merge: https://ansysproducthelpqa.win.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_generator_tree_merge.html
+.. _Userdefined: https://ansysproducthelpqa.win.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_layout_user_defined_block.html
+.. _Generator templates: https://ansysproducthelpqa.win.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_generator_templates.html
+.. _Statistical Analysis: https://ansysproducthelpqa.win.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/ad_ug_generator_statistical_analysis.html
 
 
 report_objects.TemplateREST object

--- a/doc/source/lowlevelapi/index.rst
+++ b/doc/source/lowlevelapi/index.rst
@@ -1,4 +1,4 @@
-Low Level Python API
+Low-level Python API
 ====================
 
 .. _Nexus: https://ansyshelp.ansys.com/public/account/secured?returnurl=/Views/Secured/prod_page.html?pn=Ansys%20Dynamic%20Reporting&pid=ansdynrep&lang=en

--- a/doc/source/lowlevelapi/index.rst
+++ b/doc/source/lowlevelapi/index.rst
@@ -1,7 +1,8 @@
 Low Level Python API
 ====================
 
-.. _Nexus: https://ansysproducthelpqa.win.ansys.com/public/account/secured?returnurl=Views/Secured/prod_page.html?pn=Ansys%20Dynamic%20Reporting&prodver=25.2&lang=en
+.. _Nexus: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/prod_page.html?pn=Ansys%20Dynamic%20Reporting&prodver=25.2&lang=en
+
 
 .. toctree::
    :maxdepth: 4

--- a/doc/source/lowlevelapi/index.rst
+++ b/doc/source/lowlevelapi/index.rst
@@ -1,7 +1,7 @@
 Low Level Python API
 ====================
 
-.. _Nexus: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/prod_page.html?pn=Ansys%20Dynamic%20Reporting&prodver=25.2&lang=en
+.. _Nexus: https://ansyshelp.ansys.com/public/account/secured?returnurl=/Views/Secured/prod_page.html?pn=Ansys%20Dynamic%20Reporting&pid=ansdynrep&lang=en
 
 
 .. toctree::

--- a/doc/source/lowlevelapi/index.rst
+++ b/doc/source/lowlevelapi/index.rst
@@ -1,7 +1,7 @@
 Low Level Python API
 ====================
 
-.. _Nexus: https://nexusdemo.ensight.com/docs/html/Nexus.html
+.. _Nexus: https://ansysproducthelpqa.win.ansys.com/public/account/secured?returnurl=Views/Secured/prod_page.html?pn=Ansys%20Dynamic%20Reporting&prodver=25.2&lang=en
 
 .. toctree::
    :maxdepth: 4

--- a/doc/source/userguide/index.rst
+++ b/doc/source/userguide/index.rst
@@ -150,7 +150,7 @@ Once you are connected to the session, you can query its items:
 The :func:`query<ansys.dynamicreporting.core.Service.query>` method takes
 a filter input that allows you to select the items to return. The query
 string follows the same structure as the queries described in
-`Query Expressions <hhttps://ansysproducthelpqa.win.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_query_expressions.html>`_
+`Query Expressions <https://ansysproducthelpqa.win.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_query_expressions.html>`_
 in the documentation for Ansys Dynamic Reporting.
 
 To get a list of the existing report templates in the database, use the

--- a/doc/source/userguide/index.rst
+++ b/doc/source/userguide/index.rst
@@ -150,7 +150,7 @@ Once you are connected to the session, you can query its items:
 The :func:`query<ansys.dynamicreporting.core.Service.query>` method takes
 a filter input that allows you to select the items to return. The query
 string follows the same structure as the queries described in
-`Query Expressions <https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_query_expressions.html>`_
+`Query Expressions`_
 
 in the documentation for Ansys Dynamic Reporting.
 

--- a/doc/source/userguide/index.rst
+++ b/doc/source/userguide/index.rst
@@ -150,7 +150,8 @@ Once you are connected to the session, you can query its items:
 The :func:`query<ansys.dynamicreporting.core.Service.query>` method takes
 a filter input that allows you to select the items to return. The query
 string follows the same structure as the queries described in
-`Query Expressions <https://ansysproducthelpqa.win.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_query_expressions.html>`_
+`Query Expressions <https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_query_expressions.html>`_
+
 in the documentation for Ansys Dynamic Reporting.
 
 To get a list of the existing report templates in the database, use the

--- a/doc/source/userguide/index.rst
+++ b/doc/source/userguide/index.rst
@@ -150,7 +150,7 @@ Once you are connected to the session, you can query its items:
 The :func:`query<ansys.dynamicreporting.core.Service.query>` method takes
 a filter input that allows you to select the items to return. The query
 string follows the same structure as the queries described in
-`Query Expressions <https://nexusdemo.ensight.com/docs/html/Nexus.html?QueryExpressions.html>`_
+`Query Expressions <hhttps://ansysproducthelpqa.win.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v252/en/adr_ug/adr_ug_query_expressions.html>`_
 in the documentation for Ansys Dynamic Reporting.
 
 To get a list of the existing report templates in the database, use the

--- a/src/ansys/dynamicreporting/core/adr_service.py
+++ b/src/ansys/dynamicreporting/core/adr_service.py
@@ -577,11 +577,11 @@ class Service:
             DEPRECATED. Use item_filter instead.
             Query string for filtering. The default is ``""``. The syntax corresponds
             to the syntax for Ansys Dynamic Reporting. For more information, see
-            _Query Expressions in the documentation for Ansys Dynamic Reporting.
+            _Query in the documentation for Ansys Dynamic Reporting.
         item_filter : str, optional
             Query string for filtering. The default is ``""``. The syntax corresponds
             to the syntax for Ansys Dynamic Reporting. For more information, see
-            _Query Expressions in the documentation for Ansys Dynamic Reporting.
+            _Query in the documentation for Ansys Dynamic Reporting.
 
         Returns
         -------
@@ -672,7 +672,7 @@ class Service:
         """
         Query the database.
 
-        .. _Query Expressions: https://nexusdemo.ensight.com/docs/html/Nexus.html?DataItems.html
+        .. _Query: https://ansyshelp.ansys.com/public/account/secured?returnurl=Views/Secured/corp/v251/en/adr_ug/adr_ug_query_expressions.html
 
         Parameters
         ----------
@@ -683,11 +683,11 @@ class Service:
             DEPRECATED. Use item_filter instead.
             Query string for filtering. The default is ``""``. The syntax corresponds
             to the syntax for Ansys Dynamic Reporting. For more information, see
-            _Query Expressions in the documentation for Ansys Dynamic Reporting.
+            _Query in the documentation for Ansys Dynamic Reporting.
         item_filter : str, optional
             Query string for filtering. The default is ``""``. The syntax corresponds
             to the syntax for Ansys Dynamic Reporting. For more information, see
-            _Query Expressions in the documentation for Ansys Dynamic Reporting.
+            _Query in the documentation for Ansys Dynamic Reporting.
 
         Returns
         -------


### PR DESCRIPTION
Now that the Ansys ADR documentation is available on the public site, changed the links from the old nexusdemo location to the new one.