### PR TITLE
Add directory with some default json files for report templates

### DIFF
--- a/default_templates/comparison_report.json
+++ b/default_templates/comparison_report.json
@@ -1,0 +1,720 @@
+{
+    "Template_0": {
+        "name": "Comparison Report",
+        "report_type": "Layout:basic",
+        "tags": "",
+        "item_filter": "A|i_tags|cont|'Design Point';O|i_tags|cont|ReportType=Parametric;",
+        "params": {
+            "properties": {
+                "TOCItem": "0"
+            }
+        },
+        "sort_selection": "",
+        "parent": null,
+        "guid": "0e12f6a6-6f97-4d92-85bb-0b93f54a471e",
+        "children": [
+            "Template_1",
+            "Template_2",
+            "Template_3",
+            "Template_4",
+            "Template_5",
+            "Template_6",
+            "Template_7",
+            "Template_8",
+            "Template_9"
+        ]
+    },
+    "Template_1": {
+        "name": "Top",
+        "report_type": "Layout:panel",
+        "tags": "",
+        "item_filter": "A|i_tags|cont|ReportType=Parametric;",
+        "params": {
+            "properties": {
+                "TOCItem": "0"
+            }
+        },
+        "sort_selection": "",
+        "parent": "Template_0",
+        "children": [
+            "Template_10",
+            "Template_11",
+            "Template_12",
+            "Template_13"
+        ]
+    },
+    "Template_10": {
+        "name": "Logo",
+        "report_type": "Layout:basic",
+        "tags": "",
+        "item_filter": "A|i_type|eq|image;A|i_name|eq|AnsysLogo;O|i_name|eq|UserLogo;",
+        "params": {
+            "properties": {
+                "TOCItem": "0"
+            }
+        },
+        "sort_selection": "",
+        "parent": "Template_1",
+        "children": []
+    },
+    "Template_11": {
+        "name": "Title",
+        "report_type": "Layout:basic",
+        "tags": "",
+        "item_filter": "A|i_type|eq|html;A|i_name|eq|ReportTitle;",
+        "params": {
+            "properties": {
+                "TOCItem": "0"
+            }
+        },
+        "sort_selection": "",
+        "parent": "Template_1",
+        "children": []
+    },
+    "Template_12": {
+        "name": "Header",
+        "report_type": "Layout:basic",
+        "tags": "",
+        "item_filter": "A|i_type|eq|table;A|i_name|eq|HeaderTableItem;",
+        "params": {
+            "properties": {
+                "TOCItem": "0",
+                "pagebreak": "1"
+            },
+            "HTML": "",
+            "skip_empty": 1
+        },
+        "sort_selection": "",
+        "parent": "Template_1",
+        "children": []
+    },
+    "Template_13": {
+        "name": "Table of Contents",
+        "report_type": "Layout:toc",
+        "tags": "",
+        "item_filter": "A|i_name|cont|_nothing_selected_;",
+        "params": {
+            "HTML": "<h3>Table of Contents</h3>",
+            "TOCitems": 1,
+            "TOCtables": 0,
+            "TOCfigures": 0
+        },
+        "sort_selection": "",
+        "parent": "Template_1",
+        "children": []
+    },
+    "Template_2": {
+        "name": "Design Points Table",
+        "report_type": "Layout:panel",
+        "tags": "",
+        "item_filter": "A|i_type|eq|table;A|i_name|eq|ParameterDesignPointsTable;",
+        "params": {
+            "properties": {
+                "TOCItem": "1",
+                "TOCLevel": "0",
+                "panel_template_toggle": "1",
+                "pagebreak": "1"
+            },
+            "HTML": "<h2>Design Points Table</h2>",
+            "skip_empty": 0
+        },
+        "sort_selection": "",
+        "parent": "Template_0",
+        "children": []
+    },
+    "Template_3": {
+        "name": "Base Case Simulation Setup",
+        "report_type": "Layout:panel",
+        "tags": "",
+        "item_filter": "",
+        "params": {
+            "properties": {
+                "TOCItem": "1",
+                "TOCLevel": "0",
+                "panel_template_toggle": "1",
+                "pagebreak": "1"
+            },
+            "HTML": "<h2>Base Case Simulation Setup</h2>",
+            "skip_empty": 0
+        },
+        "sort_selection": "",
+        "parent": "Template_0",
+        "children": [
+            "Template_14",
+            "Template_15"
+        ]
+    },
+    "Template_14": {
+        "name": "Physics",
+        "report_type": "Layout:panel",
+        "tags": "",
+        "item_filter": "A|i_tags|cont|'Design Point'='Base DP';O|i_type|eq|table;O|i_name|eq|ModelsTableItem;A|i_tags|cont|'Design Point'='Base DP';O|i_type|eq|tree;O|i_name|eq|MaterialsTreeItem;A|i_tags|cont|'Design Point'='Base DP';O|i_name|eq|CellZonesTreeItem;A|i_tags|cont|'Design Point'='Base DP';O|i_name|eq|BoundaryZonesTreeItem;A|i_tags|cont|'Design Point'='Base DP';O|i_name|eq|ReferenceValuesTableItem;A|i_tags|cont|'Design Point'='Base DP';",
+        "params": {
+            "properties": {
+                "TOCItem": "1",
+                "TOCLevel": "1",
+                "panel_template_toggle": "1",
+                "pagebreak": "0"
+            },
+            "HTML": "<h2>Physics</h2>",
+            "skip_empty": 0
+        },
+        "sort_selection": "",
+        "parent": "Template_3",
+        "children": [
+            "Template_16",
+            "Template_17",
+            "Template_18",
+            "Template_19",
+            "Template_20"
+        ]
+    },
+    "Template_16": {
+        "name": "Models",
+        "report_type": "Layout:basic",
+        "tags": "",
+        "item_filter": "A|i_type|eq|table;A|i_name|eq|ModelsTableItem;A|i_tags|cont|'Design Point'='Base DP';",
+        "params": {
+            "properties": {
+                "TOCItem": "1",
+                "TOCLevel": "2",
+                "pagebreak": "0"
+            },
+            "HTML": "<h2>Models</h2>",
+            "skip_empty": 0
+        },
+        "sort_selection": "",
+        "parent": "Template_14",
+        "children": []
+    },
+    "Template_17": {
+        "name": "Material Properties",
+        "report_type": "Layout:basic",
+        "tags": "",
+        "item_filter": "A|i_type|eq|tree;A|i_name|eq|MaterialsTreeItem;A|i_tags|cont|'Design Point'='Base DP';",
+        "params": {
+            "properties": {
+                "TOCItem": "1",
+                "TOCLevel": "2",
+                "pagebreak": "0"
+            },
+            "HTML": "<h2>Material Properties</h2>",
+            "skip_empty": 0
+        },
+        "sort_selection": "",
+        "parent": "Template_14",
+        "children": []
+    },
+    "Template_18": {
+        "name": "Cell Zone Conditions",
+        "report_type": "Layout:basic",
+        "tags": "",
+        "item_filter": "A|i_type|eq|tree;A|i_name|eq|CellZonesTreeItem;A|i_tags|cont|'Design Point'='Base DP';",
+        "params": {
+            "properties": {
+                "TOCItem": "1",
+                "TOCLevel": "2",
+                "pagebreak": "0"
+            },
+            "HTML": "<h2>{{\"CellZones\"|nexus_anchor}}Cell Zone Conditions</h2>",
+            "skip_empty": 0
+        },
+        "sort_selection": "",
+        "parent": "Template_14",
+        "children": []
+    },
+    "Template_19": {
+        "name": "Boundary Conditions",
+        "report_type": "Layout:basic",
+        "tags": "",
+        "item_filter": "A|i_type|eq|tree;A|i_name|eq|BoundaryZonesTreeItem;A|i_tags|cont|'Design Point'='Base DP';",
+        "params": {
+            "properties": {
+                "TOCItem": "1",
+                "TOCLevel": "2",
+                "pagebreak": "0"
+            },
+            "HTML": "<h2>{{\"BoundaryZones\"|nexus_anchor}}Boundary Conditions</h2>",
+            "skip_empty": 0
+        },
+        "sort_selection": "",
+        "parent": "Template_14",
+        "children": []
+    },
+    "Template_20": {
+        "name": "Reference Values",
+        "report_type": "Layout:basic",
+        "tags": "",
+        "item_filter": "A|i_type|eq|table;A|i_name|eq|ReferenceValuesTableItem;A|i_tags|cont|'Design Point'='Base DP';",
+        "params": {
+            "properties": {
+                "TOCItem": "1",
+                "TOCLevel": "2",
+                "pagebreak": "0"
+            },
+            "HTML": "<h2>Reference Values</h2>",
+            "skip_empty": 0
+        },
+        "sort_selection": "",
+        "parent": "Template_14",
+        "children": []
+    },
+    "Template_15": {
+        "name": "Solver Settings",
+        "report_type": "Layout:basic",
+        "tags": "",
+        "item_filter": "A|i_type|eq|tree;A|i_name|eq|SolverSettingsTreeItem;A|i_tags|cont|'Design Point'='Base DP';",
+        "params": {
+            "properties": {
+                "TOCItem": "1",
+                "TOCLevel": "1",
+                "pagebreak": "0"
+            },
+            "HTML": "<h2>Solver Settings</h2>",
+            "skip_empty": 0
+        },
+        "sort_selection": "",
+        "parent": "Template_3",
+        "children": []
+    },
+    "Template_4": {
+        "name": "Parametric Plots",
+        "report_type": "Layout:panel",
+        "tags": "",
+        "item_filter": "A|i_type|cont|table;A|i_name|cont|parametric_plot;",
+        "params": {
+            "properties": {
+                "TOCItem": "1",
+                "TOCLevel": "0",
+                "panel_template_toggle": "1",
+                "pagebreak": "1"
+            },
+            "HTML": "<h2>Parametric Plots</h2>",
+            "skip_empty": 0
+        },
+        "sort_selection": "",
+        "parent": "Template_0",
+        "children": [
+            "Template_21"
+        ]
+    },
+    "Template_21": {
+        "name": "ParametricPlotTabs",
+        "report_type": "Layout:tabs",
+        "tags": "",
+        "item_filter": "A|i_type|eq|table;A|i_name|cont|_parametric_plot;",
+        "params": {
+            "properties": {
+                "TOCItem": "0",
+                "pagebreak": "0"
+            },
+            "skip_empty": 0
+        },
+        "sort_selection": "",
+        "parent": "Template_4",
+        "children": []
+    },
+    "Template_5": {
+        "name": "Mesh",
+        "report_type": "Layout:panel",
+        "tags": "",
+        "item_filter": "A|i_type|eq|image;A|i_name|cont|_mesh;",
+        "params": {
+            "properties": {
+                "TOCItem": "1",
+                "TOCLevel": "0",
+                "panel_template_toggle": "1",
+                "pagebreak": "1"
+            },
+            "HTML": "<h2>Mesh</h2>",
+            "skip_empty": 0
+        },
+        "sort_selection": "",
+        "parent": "Template_0",
+        "children": [
+            "Template_22"
+        ]
+    },
+    "Template_22": {
+        "name": "MeshTabs",
+        "report_type": "Layout:tabs",
+        "tags": "",
+        "item_filter": "A|i_type|eq|image;A|i_name|cont|_mesh;",
+        "params": {
+            "properties": {
+                "TOCItem": "0",
+                "pagebreak": "0"
+            },
+            "skip_empty": 0
+        },
+        "sort_selection": "",
+        "parent": "Template_5",
+        "children": [
+            "Template_23",
+            "Template_24"
+        ]
+    },
+    "Template_23": {
+        "name": "Mesh Slider",
+        "report_type": "Layout:slider",
+        "tags": "",
+        "item_filter": "A|i_type|eq|image;A|i_name|cont|_mesh;",
+        "params": {
+            "properties": {
+                "TOCItem": "0",
+                "pagebreak": "0",
+                "image_title": "<h4>Mesh = {{MeshName}}, Design Point = {{Design Point}}</h4>",
+                "show_nodes": "1"
+            },
+            "HTML": "<h2>Mesh Slider</h2>",
+            "skip_empty": 0,
+            "slider_tags": "'Design Point|natural_up', 'MeshName|text_up'"
+        },
+        "sort_selection": "",
+        "parent": "Template_22",
+        "children": []
+    },
+    "Template_24": {
+        "name": "Mesh Comparison",
+        "report_type": "Layout:slider",
+        "tags": "",
+        "item_filter": "A|i_type|eq|image;A|i_name|cont|_mesh;",
+        "params": {
+            "properties": {
+                "TOCItem": "0",
+                "pagebreak": "0",
+                "image_title": "<h4>Mesh = {{MeshName}}, Design Point = {{Design Point}}</h4>",
+                "image_comparison": "1",
+                "image_controls": "1",
+                "common_slider_tags": "[MeshName]",
+                "show_nodes": "1",
+                "rgb_diff_comparison": "1"
+            },
+            "HTML": "<h2>Mesh Comparison</h2>",
+            "skip_empty": 0,
+            "slider_tags": "'Design Point|natural_up', 'MeshName|text_up'"
+        },
+        "sort_selection": "",
+        "parent": "Template_22",
+        "children": []
+    },
+    "Template_6": {
+        "name": "Contours",
+        "report_type": "Layout:panel",
+        "tags": "",
+        "item_filter": "A|i_type|eq|image;A|i_name|cont|_contour;",
+        "params": {
+            "properties": {
+                "TOCItem": "1",
+                "TOCLevel": "0",
+                "panel_template_toggle": "1",
+                "pagebreak": "1"
+            },
+            "HTML": "<h2>Contours</h2>",
+            "skip_empty": 0
+        },
+        "sort_selection": "",
+        "parent": "Template_0",
+        "children": [
+            "Template_25"
+        ]
+    },
+    "Template_25": {
+        "name": "ContourTabs",
+        "report_type": "Layout:tabs",
+        "tags": "",
+        "item_filter": "A|i_type|eq|image;A|i_name|cont|_contour;",
+        "params": {
+            "properties": {
+                "TOCItem": "0",
+                "pagebreak": "0"
+            },
+            "skip_empty": 0
+        },
+        "sort_selection": "",
+        "parent": "Template_6",
+        "children": [
+            "Template_26",
+            "Template_27"
+        ]
+    },
+    "Template_26": {
+        "name": "Contours Slider",
+        "report_type": "Layout:slider",
+        "tags": "",
+        "item_filter": "A|i_type|eq|image;A|i_name|cont|_contour;",
+        "params": {
+            "properties": {
+                "TOCItem": "0",
+                "pagebreak": "0",
+                "image_title": "<h4>Contour = {{ContourName}}, Design Point = {{Design Point}}</h4>",
+                "show_nodes": "1"
+            },
+            "HTML": "<h2>Contours Slider</h2>",
+            "skip_empty": 0,
+            "slider_tags": "'Design Point|natural_up', 'ContourName|text_up'"
+        },
+        "sort_selection": "",
+        "parent": "Template_25",
+        "children": []
+    },
+    "Template_27": {
+        "name": "Contours Comparison",
+        "report_type": "Layout:slider",
+        "tags": "",
+        "item_filter": "A|i_type|eq|image;A|i_name|cont|_contour;",
+        "params": {
+            "properties": {
+                "TOCItem": "0",
+                "pagebreak": "0",
+                "image_title": "<h4>Contour = {{ContourName}}, Design Point = {{Design Point}}</h4>",
+                "image_comparison": "1",
+                "image_controls": "1",
+                "common_slider_tags": "[ContourName]",
+                "show_nodes": "1",
+                "rgb_diff_comparison": "1"
+            },
+            "HTML": "<h2>Contours Comparison</h2>",
+            "skip_empty": 0,
+            "slider_tags": "'Design Point|natural_up', 'ContourName|text_up'"
+        },
+        "sort_selection": "",
+        "parent": "Template_25",
+        "children": []
+    },
+    "Template_7": {
+        "name": "Pathlines",
+        "report_type": "Layout:panel",
+        "tags": "",
+        "item_filter": "A|i_type|eq|image;A|i_name|cont|_pathline;",
+        "params": {
+            "properties": {
+                "TOCItem": "1",
+                "TOCLevel": "0",
+                "panel_template_toggle": "1",
+                "pagebreak": "1"
+            },
+            "HTML": "<h2>Pathlines</h2>",
+            "skip_empty": 0
+        },
+        "sort_selection": "",
+        "parent": "Template_0",
+        "children": [
+            "Template_28"
+        ]
+    },
+    "Template_28": {
+        "name": "PathlineTabs",
+        "report_type": "Layout:tabs",
+        "tags": "",
+        "item_filter": "A|i_type|eq|image;A|i_name|cont|_pathline;",
+        "params": {
+            "properties": {
+                "TOCItem": "0",
+                "pagebreak": "0"
+            },
+            "skip_empty": 0
+        },
+        "sort_selection": "",
+        "parent": "Template_7",
+        "children": [
+            "Template_29",
+            "Template_30"
+        ]
+    },
+    "Template_29": {
+        "name": "Pathlines Slider",
+        "report_type": "Layout:slider",
+        "tags": "",
+        "item_filter": "A|i_type|eq|image;A|i_name|cont|_pathline;",
+        "params": {
+            "properties": {
+                "TOCItem": "0",
+                "pagebreak": "0",
+                "image_title": "<h4>Pathline = {{PathlineName}}, Design Point = {{Design Point}}</h4>",
+                "show_nodes": "1"
+            },
+            "HTML": "<h2>Pathlines Slider</h2>",
+            "skip_empty": 0,
+            "slider_tags": "'Design Point|natural_up', 'PathlineName|text_up'"
+        },
+        "sort_selection": "",
+        "parent": "Template_28",
+        "children": []
+    },
+    "Template_30": {
+        "name": "Pathlines Comparison",
+        "report_type": "Layout:slider",
+        "tags": "",
+        "item_filter": "A|i_type|eq|image;A|i_name|cont|_pathline;",
+        "params": {
+            "properties": {
+                "TOCItem": "0",
+                "pagebreak": "0",
+                "image_title": "<h4>Pathline = {{PathlineName}}, Design Point = {{Design Point}}</h4>",
+                "image_comparison": "1",
+                "image_controls": "1",
+                "common_slider_tags": "[PathlineName]",
+                "show_nodes": "1",
+                "rgb_diff_comparison": "1"
+            },
+            "HTML": "<h2>Pathlines Comparison</h2>",
+            "skip_empty": 0,
+            "slider_tags": "'Design Point|natural_up', 'PathlineName|text_up'"
+        },
+        "sort_selection": "",
+        "parent": "Template_28",
+        "children": []
+    },
+    "Template_8": {
+        "name": "XY Plots",
+        "report_type": "Layout:panel",
+        "tags": "",
+        "item_filter": "A|i_type|eq|table;A|i_name|cont|_xyplot;",
+        "params": {
+            "properties": {
+                "TOCItem": "1",
+                "TOCLevel": "0",
+                "panel_template_toggle": "1",
+                "pagebreak": "1"
+            },
+            "HTML": "<h2>XY Plots</h2>",
+            "skip_empty": 0
+        },
+        "sort_selection": "",
+        "parent": "Template_0",
+        "children": [
+            "Template_31"
+        ]
+    },
+    "Template_31": {
+        "name": "Static Pressure",
+        "report_type": "Layout:basic",
+        "tags": "",
+        "item_filter": "A|i_name|cont|top-wall_xyplot;",
+        "params": {},
+        "sort_selection": "",
+        "parent": "Template_8",
+        "children": [
+            "Template_32"
+        ]
+    },
+    "Template_32": {
+        "name": "plot_merge",
+        "report_type": "Generator:tablemerge",
+        "tags": "",
+        "item_filter": "A|i_name|cont|_xyplot;",
+        "params": {
+            "merge_params": {
+                "column_labels_as_ids": 1,
+                "transpose_output": 0,
+                "force_numeric": 1,
+                "merge_type": "row",
+                "column_merge": "all",
+                "column_id_row": "0",
+                "collision_tag": "Design Point",
+                "unknown_value": "nan",
+                "table_name": "merged_xyplot",
+                "source_rows": "'top-wall_x|merge', '*|rename_nametag'"
+            },
+            "generate_merge": "replace",
+            "properties": {
+                "plot": "line",
+                "xaxis": "top-wall_x",
+                "line_marker": "none",
+                "xtitle": "Position [m]",
+                "Static Pressure [Pa]": "",
+                "xaxis_format": "floatdot3",
+                "yaxis_format": "scientific",
+                "ytitle": "Static Pressure [Pa]"
+            }
+        },
+        "sort_selection": "",
+        "parent": "Template_31",
+        "children": []
+    },
+    "Template_9": {
+        "name": "Scenes",
+        "report_type": "Layout:panel",
+        "tags": "",
+        "item_filter": "A|i_type|eq|image;A|i_name|cont|_scene;",
+        "params": {
+            "properties": {
+                "TOCItem": "1",
+                "TOCLevel": "0",
+                "panel_template_toggle": "1",
+                "pagebreak": "1"
+            },
+            "HTML": "<h2>Scenes</h2>",
+            "skip_empty": 0
+        },
+        "sort_selection": "",
+        "parent": "Template_0",
+        "children": [
+            "Template_33"
+        ]
+    },
+    "Template_33": {
+        "name": "SceneTabs",
+        "report_type": "Layout:tabs",
+        "tags": "",
+        "item_filter": "A|i_type|eq|image;A|i_name|cont|_scene;",
+        "params": {
+            "properties": {
+                "TOCItem": "0",
+                "pagebreak": "0"
+            },
+            "skip_empty": 0
+        },
+        "sort_selection": "",
+        "parent": "Template_9",
+        "children": [
+            "Template_34",
+            "Template_35"
+        ]
+    },
+    "Template_34": {
+        "name": "Scenes Slider",
+        "report_type": "Layout:slider",
+        "tags": "",
+        "item_filter": "A|i_type|eq|image;A|i_name|cont|_scene;",
+        "params": {
+            "properties": {
+                "TOCItem": "0",
+                "pagebreak": "0",
+                "image_title": "<h4>Scene = {{SceneName}}, Design Point = {{Design Point}}</h4>",
+                "show_nodes": "1"
+            },
+            "HTML": "<h2>Scenes Slider</h2>",
+            "skip_empty": 0,
+            "slider_tags": "'Design Point|natural_up', 'SceneName|text_up'"
+        },
+        "sort_selection": "",
+        "parent": "Template_33",
+        "children": []
+    },
+    "Template_35": {
+        "name": "Scenes Comparison",
+        "report_type": "Layout:slider",
+        "tags": "",
+        "item_filter": "A|i_type|eq|image;A|i_name|cont|_scene;",
+        "params": {
+            "properties": {
+                "TOCItem": "0",
+                "pagebreak": "0",
+                "image_title": "<h4>Scene = {{SceneName}}, Design Point = {{Design Point}}</h4>",
+                "image_comparison": "1",
+                "image_controls": "1",
+                "common_slider_tags": "[SceneName]",
+                "show_nodes": "1",
+                "rgb_diff_comparison": "1"
+            },
+            "HTML": "<h2>Scenes Comparison</h2>",
+            "skip_empty": 0,
+            "slider_tags": "'Design Point|natural_up', 'SceneName|text_up'"
+        },
+        "sort_selection": "",
+        "parent": "Template_33",
+        "children": []
+    }
+}

--- a/default_templates/generic_fea.json
+++ b/default_templates/generic_fea.json
@@ -1,0 +1,574 @@
+{
+    "Template_0": {
+        "name": "Generic FEA Report",
+        "report_type": "Layout:basic",
+        "tags": "",
+        "item_filter": "A|i_tags|cont|projectA;",
+        "params": {},
+        "sort_selection": "",
+        "parent": null,
+        "guid": "afefb5ec-c243-4d6d-b862-2204eb844cbf",
+        "children": [
+            "Template_1"
+        ]
+    },
+    "Template_1": {
+        "name": "Tag Conversion",
+        "report_type": "Layout:tagprops",
+        "tags": "",
+        "item_filter": "",
+        "params": {},
+        "sort_selection": "",
+        "parent": "Template_0",
+        "children": [
+            "Template_2",
+            "Template_3",
+            "Template_4",
+            "Template_5",
+            "Template_6",
+            "Template_7",
+            "Template_8",
+            "Template_9",
+            "Template_10",
+            "Template_11",
+            "Template_12",
+            "Template_13"
+        ]
+    },
+    "Template_2": {
+        "name": "Image",
+        "report_type": "Layout:basic",
+        "tags": "",
+        "item_filter": "A|i_tags|cont|logo;",
+        "params": {
+            "filter_type": "root_append"
+        },
+        "sort_selection": "",
+        "parent": "Template_1",
+        "children": []
+    },
+    "Template_3": {
+        "name": "Header",
+        "report_type": "Layout:basic",
+        "tags": "",
+        "item_filter": "",
+        "params": {
+            "HTML": ""
+        },
+        "sort_selection": "",
+        "parent": "Template_1",
+        "children": [
+            "Template_14"
+        ]
+    },
+    "Template_14": {
+        "name": "Title",
+        "report_type": "Layout:basic",
+        "tags": "",
+        "item_filter": "A|i_name|cont|_nothing_;",
+        "params": {
+            "HTML": "<h1><b><center>FINITE ELEMENT ANALYSIS (FEA)<center><center></b></h1> <br>\n\n    <style>  \n      .center {  \n        text-align: center;  \n        font-weight: bold;  \n      }  \n    </style> \n",
+            "properties": {},
+            "column_count": 1,
+            "column_widths": [
+                1.0
+            ]
+        },
+        "sort_selection": "",
+        "parent": "Template_3",
+        "children": []
+    },
+    "Template_4": {
+        "name": "Title Page",
+        "report_type": "Layout:panel",
+        "tags": "",
+        "item_filter": "",
+        "params": {},
+        "sort_selection": "",
+        "parent": "Template_1",
+        "children": [
+            "Template_15"
+        ]
+    },
+    "Template_15": {
+        "name": "Report Title",
+        "report_type": "Layout:basic",
+        "tags": "",
+        "item_filter": "A|i_name|cont|_nothing_;",
+        "params": {
+            "HTML": "<h1>Structural-Thermal Analysis of [Component/System]</h1>\n<br>\n<h2>Project Name</h2>\n<br>\n<h3>Author(s) and Affiliation(s)</h3>\n<br>\n<h4>Date</h4>\n<br>"
+        },
+        "sort_selection": "",
+        "parent": "Template_4",
+        "children": []
+    },
+    "Template_5": {
+        "name": "Executive Summary",
+        "report_type": "Layout:panel",
+        "tags": "",
+        "item_filter": "",
+        "params": {
+            "HTML": "<h2>Executive Summary</h2>"
+        },
+        "sort_selection": "",
+        "parent": "Template_1",
+        "children": [
+            "Template_16"
+        ]
+    },
+    "Template_16": {
+        "name": "Overview",
+        "report_type": "Layout:basic",
+        "tags": "",
+        "item_filter": "A|i_name|cont|overview;",
+        "params": {
+            "HTML": "<p>Brief overview of the project</p>\n<br>\n<p>Key findings and results for structural and thermal analysis</p>\n<br>\n<p>Recommendations or conclusions</p>"
+        },
+        "sort_selection": "",
+        "parent": "Template_5",
+        "children": []
+    },
+    "Template_6": {
+        "name": "Table of Contents",
+        "report_type": "Layout:toc",
+        "tags": "",
+        "item_filter": "",
+        "params": {
+            "HTML": "<h2>Table of Contents</h2>",
+            "properties": {},
+            "TOCfigures": 0,
+            "TOCitems": 1
+        },
+        "sort_selection": "",
+        "parent": "Template_1",
+        "children": []
+    },
+    "Template_7": {
+        "name": "Introduction",
+        "report_type": "Layout:panel",
+        "tags": "",
+        "item_filter": "",
+        "params": {
+            "HTML": "<h2>Introduction</h2>",
+            "properties": {
+                "TOCItem": "1"
+            }
+        },
+        "sort_selection": "",
+        "parent": "Template_1",
+        "children": [
+            "Template_17",
+            "Template_18",
+            "Template_19",
+            "Template_20"
+        ]
+    },
+    "Template_17": {
+        "name": "Background",
+        "report_type": "Layout:basic",
+        "tags": "",
+        "item_filter": "A|i_tags|cont|section=background;",
+        "params": {
+            "HTML": "<p>Background of the project</p>",
+            "properties": {
+                "TOCLevel": "1"
+            }
+        },
+        "sort_selection": "",
+        "parent": "Template_7",
+        "children": []
+    },
+    "Template_18": {
+        "name": "Problem Statement",
+        "report_type": "Layout:basic",
+        "tags": "",
+        "item_filter": "A|i_tags|cont|section=problem;",
+        "params": {
+            "HTML": "<p>Problem statement</p>"
+        },
+        "sort_selection": "",
+        "parent": "Template_7",
+        "children": []
+    },
+    "Template_19": {
+        "name": "Objectives",
+        "report_type": "Layout:basic",
+        "tags": "",
+        "item_filter": "A|i_tags|cont|section=objectives;",
+        "params": {
+            "HTML": "<p>Objectives of the structural-thermal analysis</p>"
+        },
+        "sort_selection": "",
+        "parent": "Template_7",
+        "children": []
+    },
+    "Template_20": {
+        "name": "Scope",
+        "report_type": "Layout:basic",
+        "tags": "",
+        "item_filter": "A|i_tags|cont|section=scope;",
+        "params": {
+            "HTML": "<p>Scope and limitations</p>"
+        },
+        "sort_selection": "",
+        "parent": "Template_7",
+        "children": []
+    },
+    "Template_8": {
+        "name": "Methodology",
+        "report_type": "Layout:panel",
+        "tags": "",
+        "item_filter": "A|i_tags|cont|chapter=methodology;",
+        "params": {
+            "HTML": "<h2>Methodology</h2>",
+            "properties": {
+                "TOCItem": "1",
+                "TOCLevel": "0"
+            }
+        },
+        "sort_selection": "",
+        "parent": "Template_1",
+        "children": [
+            "Template_21",
+            "Template_22",
+            "Template_23",
+            "Template_24",
+            "Template_25"
+        ]
+    },
+    "Template_21": {
+        "name": "Geometry and Mesh Generation",
+        "report_type": "Layout:basic",
+        "tags": "",
+        "item_filter": "A|i_tags|cont|section=mesh;",
+        "params": {
+            "HTML": "<p>Description of the geometry and mesh used for both structural and thermal analyses</p>",
+            "properties": {
+                "TOCLevel": "1"
+            }
+        },
+        "sort_selection": "",
+        "parent": "Template_8",
+        "children": []
+    },
+    "Template_22": {
+        "name": "Material Properties",
+        "report_type": "Layout:basic",
+        "tags": "",
+        "item_filter": "A|i_tags|cont|section=materials;",
+        "params": {
+            "HTML": "<p>Material properties relevant to structural and thermal analyses</p>",
+            "properties": {
+                "TOCLevel": "1"
+            }
+        },
+        "sort_selection": "",
+        "parent": "Template_8",
+        "children": []
+    },
+    "Template_23": {
+        "name": "Structural Analysis",
+        "report_type": "Layout:basic",
+        "tags": "",
+        "item_filter": "A|i_tags|cont|section=structural;",
+        "params": {
+            "HTML": "<p>Boundary conditions and loads</p>",
+            "properties": {
+                "TOCLevel": "1"
+            }
+        },
+        "sort_selection": "",
+        "parent": "Template_8",
+        "children": []
+    },
+    "Template_24": {
+        "name": "Thermal Analysis",
+        "report_type": "Layout:basic",
+        "tags": "",
+        "item_filter": "A|i_tags|cont|section=thermal;",
+        "params": {
+            "HTML": "<p>Thermal boundary conditions</p>",
+            "properties": {
+                "TOCLevel": "1"
+            }
+        },
+        "sort_selection": "",
+        "parent": "Template_8",
+        "children": []
+    },
+    "Template_25": {
+        "name": "Coupling of Structural and Thermal Analysis",
+        "report_type": "Layout:basic",
+        "tags": "",
+        "item_filter": "A|i_tags|cont|section=coupled;",
+        "params": {
+            "HTML": "<p>Description of the coupling method</p>",
+            "properties": {
+                "TOCLevel": "1"
+            }
+        },
+        "sort_selection": "",
+        "parent": "Template_8",
+        "children": []
+    },
+    "Template_9": {
+        "name": "Results",
+        "report_type": "Layout:panel",
+        "tags": "",
+        "item_filter": "A|i_tags|cont|chapter=results;",
+        "params": {
+            "HTML": "<h2>Results</h2>",
+            "properties": {
+                "TOCItem": "1",
+                "TOCLevel": "0"
+            }
+        },
+        "sort_selection": "",
+        "parent": "Template_1",
+        "children": [
+            "Template_26",
+            "Template_27",
+            "Template_28"
+        ]
+    },
+    "Template_26": {
+        "name": "Structural Analysis Results",
+        "report_type": "Layout:basic",
+        "tags": "",
+        "item_filter": "A|i_tags|cont|result=structural;",
+        "params": {
+            "HTML": "<p>Stress, strain, and displacement distributions</p>",
+            "properties": {
+                "TOCLevel": "1"
+            }
+        },
+        "sort_selection": "",
+        "parent": "Template_9",
+        "children": []
+    },
+    "Template_27": {
+        "name": "Thermal Analysis Results",
+        "report_type": "Layout:basic",
+        "tags": "",
+        "item_filter": "A|i_tags|cont|section=thermal;",
+        "params": {
+            "HTML": "<p>Temperature distributions</p>",
+            "properties": {
+                "TOCLevel": "1"
+            }
+        },
+        "sort_selection": "",
+        "parent": "Template_9",
+        "children": []
+    },
+    "Template_28": {
+        "name": "Coupled Structural-Thermal Results",
+        "report_type": "Layout:basic",
+        "tags": "",
+        "item_filter": "A|i_tags|cont|section=coupled;",
+        "params": {
+            "HTML": "<p>Combined effects of structural and thermal loads</p>",
+            "properties": {
+                "TOCLevel": "1"
+            }
+        },
+        "sort_selection": "",
+        "parent": "Template_9",
+        "children": []
+    },
+    "Template_10": {
+        "name": "Discussion",
+        "report_type": "Layout:panel",
+        "tags": "",
+        "item_filter": "A|i_tags|cont|chapter=discussion;",
+        "params": {
+            "HTML": "<h2>Discussion</h2>",
+            "properties": {
+                "TOCItem": "1",
+                "TOCLevel": "0"
+            }
+        },
+        "sort_selection": "",
+        "parent": "Template_1",
+        "children": [
+            "Template_29",
+            "Template_30",
+            "Template_31"
+        ]
+    },
+    "Template_29": {
+        "name": "Structural Analysis Discussion",
+        "report_type": "Layout:basic",
+        "tags": "",
+        "item_filter": "A|i_tags|cont|section=structural;",
+        "params": {
+            "HTML": "<p>Interpretation of stress, strain, and displacement results</p>",
+            "properties": {
+                "TOCLevel": "1"
+            }
+        },
+        "sort_selection": "",
+        "parent": "Template_10",
+        "children": []
+    },
+    "Template_30": {
+        "name": "Thermal Analysis Discussion",
+        "report_type": "Layout:basic",
+        "tags": "",
+        "item_filter": "A|i_tags|cont|section=thermal;",
+        "params": {
+            "HTML": "<p>Interpretation of temperature and heat flux results</p>",
+            "properties": {
+                "TOCLevel": "1"
+            }
+        },
+        "sort_selection": "",
+        "parent": "Template_10",
+        "children": []
+    },
+    "Template_31": {
+        "name": "Coupled Structural-Thermal Discussion",
+        "report_type": "Layout:basic",
+        "tags": "",
+        "item_filter": "A|i_tags|cont|section=coupled;",
+        "params": {
+            "HTML": "<p>Analysis of the combined effects of structural and thermal loads</p>",
+            "properties": {
+                "TOCLevel": "1"
+            }
+        },
+        "sort_selection": "",
+        "parent": "Template_10",
+        "children": []
+    },
+    "Template_11": {
+        "name": "References",
+        "report_type": "Layout:panel",
+        "tags": "",
+        "item_filter": "",
+        "params": {
+            "HTML": "<h2>References</h2>",
+            "properties": {
+                "TOCItem": "1"
+            }
+        },
+        "sort_selection": "",
+        "parent": "Template_1",
+        "children": [
+            "Template_32"
+        ]
+    },
+    "Template_32": {
+        "name": "Ref",
+        "report_type": "Layout:basic",
+        "tags": "",
+        "item_filter": "A|i_name|cont|references;",
+        "params": {
+            "HTML": "<p>1. [Author(s) Last name, First initial(s)]. (Year of publication). Title of the journal article. _Title of the Journal, volume(issue)_, page range. DOI or URL</p>",
+            "properties": {
+                "TOCItem": "0"
+            }
+        },
+        "sort_selection": "",
+        "parent": "Template_11",
+        "children": []
+    },
+    "Template_12": {
+        "name": "Conclusions",
+        "report_type": "Layout:panel",
+        "tags": "",
+        "item_filter": "A|i_tags|cont|chapter=conclusions;",
+        "params": {
+            "HTML": "<h2>Conclusions</h2>",
+            "properties": {
+                "TOCItem": "1",
+                "TOCLevel": "0"
+            }
+        },
+        "sort_selection": "",
+        "parent": "Template_1",
+        "children": [
+            "Template_33",
+            "Template_34"
+        ]
+    },
+    "Template_33": {
+        "name": "Summary",
+        "report_type": "Layout:basic",
+        "tags": "",
+        "item_filter": "A|i_tags|cont|section=summary;",
+        "params": {
+            "HTML": "<p>Summary of key findings</p>",
+            "properties": {
+                "TOCLevel": "1"
+            }
+        },
+        "sort_selection": "",
+        "parent": "Template_12",
+        "children": []
+    },
+    "Template_34": {
+        "name": "Recommendations",
+        "report_type": "Layout:basic",
+        "tags": "",
+        "item_filter": "A|i_tags|cont|section=recommendations;",
+        "params": {
+            "HTML": "<p>Recommendations for further work or design improvements</p>",
+            "properties": {
+                "TOCLevel": "1"
+            }
+        },
+        "sort_selection": "",
+        "parent": "Template_12",
+        "children": []
+    },
+    "Template_13": {
+        "name": "Appendices",
+        "report_type": "Layout:panel",
+        "tags": "",
+        "item_filter": "A|i_name|cont|chapter=appendices;",
+        "params": {
+            "HTML": "<h2>Appendices</h2>",
+            "properties": {
+                "TOCItem": "1",
+                "TOCLevel": "0"
+            }
+        },
+        "sort_selection": "",
+        "parent": "Template_1",
+        "children": [
+            "Template_35",
+            "Template_36"
+        ]
+    },
+    "Template_35": {
+        "name": "Appendix-A",
+        "report_type": "Layout:basic",
+        "tags": "",
+        "item_filter": "A|i_tags|cont|section=appendixA;",
+        "params": {
+            "HTML": "<p>Appendix A</p>",
+            "properties": {
+                "TOCLevel": "1"
+            }
+        },
+        "sort_selection": "",
+        "parent": "Template_13",
+        "children": []
+    },
+    "Template_36": {
+        "name": "Appendix-B",
+        "report_type": "Layout:basic",
+        "tags": "",
+        "item_filter": "A|i_tags|cont|section=appendixA;",
+        "params": {
+            "HTML": "<p>Appendix B</p>",
+            "properties": {
+                "TOCLevel": "1"
+            }
+        },
+        "sort_selection": "",
+        "parent": "Template_13",
+        "children": []
+    }
+}

--- a/default_templates/pptx_export.json
+++ b/default_templates/pptx_export.json
@@ -1,0 +1,568 @@
+{
+    "Template_0": {
+        "name": "Test_ppt",
+        "report_type": "Layout:pptx",
+        "tags": "",
+        "item_filter": "",
+        "params": {
+            "properties": {
+                "input_pptx": "Ansys Fluent Simulation Report_input_ppt.pptx",
+                "output_pptx": "Ansys_Fluent_Simulation_Report.pptx",
+                "use_all_slides": "0"
+            }
+        },
+        "sort_selection": "",
+        "parent": null,
+        "guid": "07ac56d8-8278-4401-adc2-491ec5a9ba7e",
+        "children": [
+            "Template_1",
+            "Template_2",
+            "Template_3",
+            "Template_4",
+            "Template_5",
+            "Template_6",
+            "Template_7",
+            "Template_8",
+            "Template_9",
+            "Template_10",
+            "Template_11",
+            "Template_12",
+            "Template_13",
+            "Template_14"
+        ]
+    },
+    "Template_1": {
+        "name": "ReportTitleText_template_ppt",
+        "report_type": "Layout:pptxslide",
+        "tags": "",
+        "item_filter": "",
+        "params": {
+            "properties": {
+                "source_slide": 1,
+                "exclude_from_toc": "1"
+            },
+            "HTML": "<h2>Ansys Fluent Simulation Report</h2>"
+        },
+        "sort_selection": "",
+        "parent": "Template_0",
+        "children": []
+    },
+    "Template_2": {
+        "name": "TOC_template_ppt",
+        "report_type": "Layout:pptxslide",
+        "tags": "",
+        "item_filter": "",
+        "params": {
+            "properties": {
+                "source_slide": 3,
+                "exclude_from_toc": "1"
+            },
+            "HTML": "<h2>Table of Contents</h2>"
+        },
+        "sort_selection": "",
+        "parent": "Template_0",
+        "children": []
+    },
+    "Template_3": {
+        "name": "Header_template_ppt",
+        "report_type": "Layout:pptxslide",
+        "tags": "",
+        "item_filter": "A|i_type|eq|table;A|i_name|eq|HeaderTableItem;",
+        "params": {
+            "properties": {
+                "source_slide": 2,
+                "exclude_from_toc": "1"
+            },
+            "HTML": "<h2>Header</h2>",
+            "comments": ""
+        },
+        "sort_selection": "",
+        "parent": "Template_0",
+        "children": []
+    },
+    "Template_4": {
+        "name": "System Information_template_ppt",
+        "report_type": "Layout:pptxslide",
+        "tags": "",
+        "item_filter": "A|i_type|eq|table;A|i_name|eq|SystemTableItem;",
+        "params": {
+            "properties": {
+                "source_slide": 4,
+                "exclude_from_toc": "0"
+            },
+            "HTML": "<h2>System Information</h2>",
+            "comments": ""
+        },
+        "sort_selection": "",
+        "parent": "Template_0",
+        "children": []
+    },
+    "Template_5": {
+        "name": "Geometry and Mesh_template_ppt",
+        "report_type": "Layout:pptxslide",
+        "tags": "",
+        "item_filter": "A|i_type|eq|table;A|i_name|eq|MeshSizeTableItem;O|i_name|eq|MeshQualityTableItem;O|i_type|eq|image;O|i_name|eq|MeshOrthogonalHistogram;",
+        "params": {
+            "properties": {
+                "source_slide": 5,
+                "exclude_from_toc": "0"
+            },
+            "HTML": "<h2>Geometry and Mesh</h2>",
+            "comments": ""
+        },
+        "sort_selection": "",
+        "parent": "Template_0",
+        "children": [
+            "Template_15",
+            "Template_16",
+            "Template_17"
+        ]
+    },
+    "Template_15": {
+        "name": "Mesh Size_template_ppt",
+        "report_type": "Layout:pptxslide",
+        "tags": "",
+        "item_filter": "A|i_type|eq|table;A|i_name|eq|MeshSizeTableItem;",
+        "params": {
+            "properties": {
+                "source_slide": 6,
+                "exclude_from_toc": "0"
+            },
+            "HTML": "<h2>Mesh Size</h2>",
+            "comments": ""
+        },
+        "sort_selection": "",
+        "parent": "Template_5",
+        "children": []
+    },
+    "Template_16": {
+        "name": "Mesh Quality_template_ppt",
+        "report_type": "Layout:pptxslide",
+        "tags": "",
+        "item_filter": "A|i_type|eq|table;A|i_name|eq|MeshQualityTableItem;",
+        "params": {
+            "properties": {
+                "source_slide": 7,
+                "exclude_from_toc": "0"
+            },
+            "HTML": "<h2>Mesh Quality</h2>",
+            "comments": ""
+        },
+        "sort_selection": "",
+        "parent": "Template_5",
+        "children": []
+    },
+    "Template_17": {
+        "name": "Orthogonal Quality_template_ppt",
+        "report_type": "Layout:pptxslide",
+        "tags": "",
+        "item_filter": "A|i_type|eq|image;A|i_name|eq|MeshOrthogonalHistogram;",
+        "params": {
+            "properties": {
+                "source_slide": 8,
+                "exclude_from_toc": "0"
+            },
+            "HTML": "<h2>Orthogonal Quality</h2>",
+            "comments": ""
+        },
+        "sort_selection": "",
+        "parent": "Template_5",
+        "children": []
+    },
+    "Template_6": {
+        "name": "Simulation Setup_template_ppt",
+        "report_type": "Layout:pptxslide",
+        "tags": "",
+        "item_filter": "A|i_type|eq|table;A|i_name|eq|ModelsTableItem;O|i_type|eq|tree;O|i_name|eq|MaterialsTreeItem;O|i_name|eq|CellZonesTreeItem;O|i_name|eq|BoundaryZonesTreeItem;O|i_name|eq|ReferenceValuesTableItem;O|i_name|eq|SolverSettingsTreeItem;",
+        "params": {
+            "properties": {
+                "source_slide": 9,
+                "exclude_from_toc": "0"
+            },
+            "HTML": "<h2>Simulation Setup</h2>",
+            "comments": ""
+        },
+        "sort_selection": "",
+        "parent": "Template_0",
+        "children": [
+            "Template_18",
+            "Template_19"
+        ]
+    },
+    "Template_18": {
+        "name": "Physics_template_ppt",
+        "report_type": "Layout:pptxslide",
+        "tags": "",
+        "item_filter": "A|i_type|eq|table;A|i_name|eq|ModelsTableItem;O|i_type|eq|tree;O|i_name|eq|MaterialsTreeItem;O|i_name|eq|CellZonesTreeItem;O|i_name|eq|BoundaryZonesTreeItem;O|i_name|eq|ReferenceValuesTableItem;",
+        "params": {
+            "properties": {
+                "source_slide": 10,
+                "exclude_from_toc": "0"
+            },
+            "HTML": "<h2>Physics</h2>",
+            "comments": ""
+        },
+        "sort_selection": "",
+        "parent": "Template_6",
+        "children": [
+            "Template_20",
+            "Template_21",
+            "Template_22",
+            "Template_23",
+            "Template_24"
+        ]
+    },
+    "Template_20": {
+        "name": "Models_template_ppt",
+        "report_type": "Layout:pptxslide",
+        "tags": "dataset=4b878171-05af-11f0-a78e-743af4bc475f",
+        "item_filter": "A|i_type|eq|table;A|i_name|eq|ModelsTableItem;",
+        "params": {
+            "properties": {
+                "source_slide": 11,
+                "exclude_from_toc": "0"
+            },
+            "HTML": "<h2>Models</h2>",
+            "comments": ""
+        },
+        "sort_selection": "",
+        "parent": "Template_18",
+        "children": []
+    },
+    "Template_21": {
+        "name": "Material Properties_template_ppt",
+        "report_type": "Layout:pptxslide",
+        "tags": "dataset=4b878171-05af-11f0-a78e-743af4bc475f",
+        "item_filter": "A|i_type|eq|tree;A|i_name|eq|MaterialsTreeItem;",
+        "params": {
+            "properties": {
+                "source_slide": 12,
+                "exclude_from_toc": "0"
+            },
+            "HTML": "<h2>Material Properties</h2>",
+            "comments": ""
+        },
+        "sort_selection": "",
+        "parent": "Template_18",
+        "children": []
+    },
+    "Template_22": {
+        "name": "Cell Zone Conditions_template_ppt",
+        "report_type": "Layout:pptxslide",
+        "tags": "dataset=4b878171-05af-11f0-a78e-743af4bc475f",
+        "item_filter": "A|i_type|eq|tree;A|i_name|eq|CellZonesTreeItem;",
+        "params": {
+            "properties": {
+                "source_slide": 13,
+                "exclude_from_toc": "0"
+            },
+            "HTML": "<h2>Cell Zone Conditions</h2>",
+            "comments": ""
+        },
+        "sort_selection": "",
+        "parent": "Template_18",
+        "children": []
+    },
+    "Template_23": {
+        "name": "Boundary Conditions_template_ppt",
+        "report_type": "Layout:pptxslide",
+        "tags": "dataset=4b878171-05af-11f0-a78e-743af4bc475f",
+        "item_filter": "A|i_type|eq|tree;A|i_name|eq|BoundaryZonesTreeItem;",
+        "params": {
+            "properties": {
+                "source_slide": 14,
+                "exclude_from_toc": "0"
+            },
+            "HTML": "<h2>Boundary Conditions</h2>",
+            "comments": ""
+        },
+        "sort_selection": "",
+        "parent": "Template_18",
+        "children": []
+    },
+    "Template_24": {
+        "name": "Reference Values_template_ppt",
+        "report_type": "Layout:pptxslide",
+        "tags": "dataset=4b878171-05af-11f0-a78e-743af4bc475f",
+        "item_filter": "A|i_type|eq|table;A|i_name|eq|ReferenceValuesTableItem;",
+        "params": {
+            "properties": {
+                "source_slide": 15,
+                "exclude_from_toc": "0"
+            },
+            "HTML": "<h2>Reference Values</h2>",
+            "comments": ""
+        },
+        "sort_selection": "",
+        "parent": "Template_18",
+        "children": []
+    },
+    "Template_19": {
+        "name": "Solver Settings_template_ppt",
+        "report_type": "Layout:pptxslide",
+        "tags": "",
+        "item_filter": "A|i_type|eq|tree;A|i_name|eq|SolverSettingsTreeItem;",
+        "params": {
+            "properties": {
+                "source_slide": 16,
+                "exclude_from_toc": "0"
+            },
+            "HTML": "<h2>Solver Settings</h2>",
+            "comments": ""
+        },
+        "sort_selection": "",
+        "parent": "Template_6",
+        "children": []
+    },
+    "Template_7": {
+        "name": "Run Information_template_ppt",
+        "report_type": "Layout:pptxslide",
+        "tags": "",
+        "item_filter": "A|i_type|eq|table;A|i_name|eq|RunTableItem;",
+        "params": {
+            "properties": {
+                "source_slide": 17,
+                "exclude_from_toc": "0"
+            },
+            "HTML": "<h2>Run Information</h2>",
+            "comments": ""
+        },
+        "sort_selection": "",
+        "parent": "Template_0",
+        "children": []
+    },
+    "Template_8": {
+        "name": "Solution Status_template_ppt",
+        "report_type": "Layout:pptxslide",
+        "tags": "",
+        "item_filter": "A|i_type|eq|table;A|i_name|eq|SolverStatusTableItem;",
+        "params": {
+            "properties": {
+                "source_slide": 18,
+                "exclude_from_toc": "0"
+            },
+            "HTML": "<h2>Solution Status</h2><h4>Iterations: 65</h4>",
+            "comments": ""
+        },
+        "sort_selection": "",
+        "parent": "Template_0",
+        "children": []
+    },
+    "Template_9": {
+        "name": "Named Expressions_template_ppt",
+        "report_type": "Layout:pptxslide",
+        "tags": "",
+        "item_filter": "A|i_type|eq|table;A|i_name|eq|ExpressionsTableItem;",
+        "params": {
+            "properties": {
+                "source_slide": 19,
+                "exclude_from_toc": "0"
+            },
+            "HTML": "<h2>Named Expressions</h2>",
+            "comments": ""
+        },
+        "sort_selection": "",
+        "parent": "Template_0",
+        "children": []
+    },
+    "Template_10": {
+        "name": "Report Definitions_template_ppt",
+        "report_type": "Layout:pptxslide",
+        "tags": "",
+        "item_filter": "A|i_type|eq|tree;A|i_name|eq|ReportDefinitionsTreeItem;",
+        "params": {
+            "properties": {
+                "source_slide": 20,
+                "exclude_from_toc": "0"
+            },
+            "HTML": "<h2>Report Definitions</h2>",
+            "comments": ""
+        },
+        "sort_selection": "",
+        "parent": "Template_0",
+        "children": []
+    },
+    "Template_11": {
+        "name": "Plots_template_ppt",
+        "report_type": "Layout:pptxslide",
+        "tags": "",
+        "item_filter": "A|i_type|eq|table;A|i_name|cont|_plot;",
+        "params": {
+            "properties": {
+                "source_slide": 21,
+                "exclude_from_toc": "0"
+            },
+            "HTML": "<h2>Plots</h2>",
+            "comments": ""
+        },
+        "sort_selection": "",
+        "parent": "Template_0",
+        "children": [
+            "Template_25",
+            "Template_26"
+        ]
+    },
+    "Template_25": {
+        "name": "Residuals_template_ppt",
+        "report_type": "Layout:pptxslide",
+        "tags": "",
+        "item_filter": "A|i_type|eq|table;A|i_name|eq|residuals_plot;",
+        "params": {
+            "properties": {
+                "source_slide": 22,
+                "exclude_from_toc": "0",
+                "pptx_legend_position": "bottom",
+                "pptx_log_base": "10"
+            },
+            "HTML": "<h2>Residuals</h2>"
+        },
+        "sort_selection": "",
+        "parent": "Template_11",
+        "children": []
+    },
+    "Template_26": {
+        "name": "Report Plots_template_ppt",
+        "report_type": "Layout:pptxslide",
+        "tags": "",
+        "item_filter": "A|i_type|eq|table;A|i_name|cont|_plot;",
+        "params": {
+            "properties": {
+                "source_slide": 23,
+                "exclude_from_toc": "0"
+            },
+            "HTML": "<h2>Report Plots</h2>",
+            "comments": ""
+        },
+        "sort_selection": "",
+        "parent": "Template_11",
+        "children": [
+            "Template_27"
+        ]
+    },
+    "Template_27": {
+        "name": "Report Plots_child_template_ppt",
+        "report_type": "Layout:pptxslide",
+        "tags": "",
+        "item_filter": "A|i_name|cont|_plot;",
+        "params": {
+            "properties": {
+                "source_slide": 24,
+                "exclude_from_toc": "1",
+                "pptx_legend_position": "bottom",
+                "show_tag_title_only": "1"
+            },
+            "HTML": "<h2>report plots</h2>"
+        },
+        "sort_selection": "",
+        "parent": "Template_26",
+        "children": []
+    },
+    "Template_12": {
+        "name": "Mesh_template_ppt",
+        "report_type": "Layout:pptxslide",
+        "tags": "",
+        "item_filter": "A|i_type|eq|image;A|i_name|cont|_mesh;",
+        "params": {
+            "properties": {
+                "source_slide": 25,
+                "exclude_from_toc": "0"
+            },
+            "HTML": "<h2>Mesh</h2>",
+            "comments": ""
+        },
+        "sort_selection": "",
+        "parent": "Template_0",
+        "children": [
+            "Template_28"
+        ]
+    },
+    "Template_28": {
+        "name": "Mesh_child_template_ppt",
+        "report_type": "Layout:pptxslide",
+        "tags": "",
+        "item_filter": "A|i_name|cont|_mesh;",
+        "params": {
+            "properties": {
+                "source_slide": 26,
+                "exclude_from_toc": "1",
+                "show_tag_title_only": "1"
+            },
+            "HTML": "<h2>mesh</h2>"
+        },
+        "sort_selection": "",
+        "parent": "Template_12",
+        "children": []
+    },
+    "Template_13": {
+        "name": "Pathlines_template_ppt",
+        "report_type": "Layout:pptxslide",
+        "tags": "",
+        "item_filter": "A|i_type|eq|image;A|i_name|cont|_pathline;",
+        "params": {
+            "properties": {
+                "source_slide": 31,
+                "exclude_from_toc": "0"
+            },
+            "HTML": "<h2>Pathlines</h2>",
+            "comments": ""
+        },
+        "sort_selection": "",
+        "parent": "Template_0",
+        "children": [
+            "Template_29"
+        ]
+    },
+    "Template_29": {
+        "name": "Pathlines_child_template_ppt",
+        "report_type": "Layout:pptxslide",
+        "tags": "",
+        "item_filter": "A|i_name|cont|_pathline;",
+        "params": {
+            "properties": {
+                "source_slide": 32,
+                "exclude_from_toc": "1",
+                "show_tag_title_only": "1"
+            },
+            "HTML": "<h2>pathlines</h2>"
+        },
+        "sort_selection": "",
+        "parent": "Template_13",
+        "children": []
+    },
+    "Template_14": {
+        "name": "Contours_template_ppt",
+        "report_type": "Layout:pptxslide",
+        "tags": "",
+        "item_filter": "A|i_type|eq|image;A|i_name|cont|_contour;",
+        "params": {
+            "properties": {
+                "source_slide": 27,
+                "exclude_from_toc": "0"
+            },
+            "HTML": "<h2>Contours</h2>",
+            "comments": ""
+        },
+        "sort_selection": "",
+        "parent": "Template_0",
+        "children": [
+            "Template_30"
+        ]
+    },
+    "Template_30": {
+        "name": "Contours_child_template_ppt",
+        "report_type": "Layout:pptxslide",
+        "tags": "",
+        "item_filter": "A|i_name|cont|_contour;",
+        "params": {
+            "properties": {
+                "source_slide": 28,
+                "exclude_from_toc": "1",
+                "show_tag_title_only": "1"
+            },
+            "HTML": "<h2>contours</h2>"
+        },
+        "sort_selection": "",
+        "parent": "Template_14",
+        "children": []
+    }
+}

--- a/default_templates/single_report.json
+++ b/default_templates/single_report.json
@@ -1,0 +1,792 @@
+{
+    "Template_0": {
+        "name": "Single Simulation Report",
+        "report_type": "Layout:basic",
+        "tags": "",
+        "item_filter": "A|i_tags|cont|simulation=runA;",
+        "params": {
+            "properties": {
+                "TOCItem": "0"
+            }
+        },
+        "sort_selection": "",
+        "parent": null,
+        "guid": "ff0c691a-1d73-44ba-a0c6-6b2ee6a2b909",
+        "children": [
+            "Template_1",
+            "Template_2",
+            "Template_3",
+            "Template_4",
+            "Template_5",
+            "Template_6",
+            "Template_7",
+            "Template_8",
+            "Template_9",
+            "Template_10",
+            "Template_11",
+            "Template_12"
+        ]
+    },
+    "Template_1": {
+        "name": "Top",
+        "report_type": "Layout:panel",
+        "tags": "",
+        "item_filter": "",
+        "params": {
+            "properties": {
+                "TOCItem": "0"
+            }
+        },
+        "sort_selection": "",
+        "parent": "Template_0",
+        "children": [
+            "Template_13",
+            "Template_14",
+            "Template_15",
+            "Template_16"
+        ]
+    },
+    "Template_13": {
+        "name": "Logo",
+        "report_type": "Layout:basic",
+        "tags": "",
+        "item_filter": "A|i_type|cont|image;A|i_name|eq|AnsysLogo;O|i_name|eq|UserLogo;",
+        "params": {
+            "properties": {
+                "TOCItem": "0"
+            },
+            "filter_type": "root_replace"
+        },
+        "sort_selection": "",
+        "parent": "Template_1",
+        "children": []
+    },
+    "Template_14": {
+        "name": "Title",
+        "report_type": "Layout:basic",
+        "tags": "",
+        "item_filter": "A|i_type|eq|html;A|i_name|eq|ReportTitle;",
+        "params": {
+            "properties": {
+                "TOCItem": "0"
+            }
+        },
+        "sort_selection": "",
+        "parent": "Template_1",
+        "children": []
+    },
+    "Template_15": {
+        "name": "Header",
+        "report_type": "Layout:basic",
+        "tags": "",
+        "item_filter": "A|i_type|eq|table;A|i_name|eq|HeaderTableItem;",
+        "params": {
+            "properties": {
+                "TOCItem": "0",
+                "pagebreak": "1"
+            },
+            "HTML": "",
+            "skip_empty": 1
+        },
+        "sort_selection": "",
+        "parent": "Template_1",
+        "children": []
+    },
+    "Template_16": {
+        "name": "Table of Contents",
+        "report_type": "Layout:toc",
+        "tags": "",
+        "item_filter": "A|i_name|cont|_nothing_selected_;",
+        "params": {
+            "HTML": "<h3>Table of Contents</h3>",
+            "TOCitems": 1,
+            "TOCtables": 0,
+            "TOCfigures": 0
+        },
+        "sort_selection": "",
+        "parent": "Template_1",
+        "children": []
+    },
+    "Template_2": {
+        "name": "System Information",
+        "report_type": "Layout:panel",
+        "tags": "",
+        "item_filter": "A|i_type|cont|table;A|i_name|eq|SystemTableItem;",
+        "params": {
+            "properties": {
+                "TOCItem": "1",
+                "TOCLevel": "0",
+                "panel_template_toggle": "1",
+                "pagebreak": "1"
+            },
+            "HTML": "<h2>System Information</h2>",
+            "skip_empty": 0
+        },
+        "sort_selection": "",
+        "parent": "Template_0",
+        "children": []
+    },
+    "Template_3": {
+        "name": "Geometry and Mesh",
+        "report_type": "Layout:panel",
+        "tags": "",
+        "item_filter": "",
+        "params": {
+            "properties": {
+                "TOCItem": "1",
+                "TOCLevel": "0",
+                "panel_template_toggle": "1",
+                "pagebreak": "1"
+            },
+            "HTML": "<h2>Geometry and Mesh</h2>",
+            "skip_empty": 0
+        },
+        "sort_selection": "",
+        "parent": "Template_0",
+        "children": [
+            "Template_17",
+            "Template_18",
+            "Template_19"
+        ]
+    },
+    "Template_17": {
+        "name": "Mesh Size",
+        "report_type": "Layout:basic",
+        "tags": "",
+        "item_filter": "A|i_type|cont|table;A|i_name|eq|MeshSizeTableItem;",
+        "params": {
+            "properties": {
+                "TOCItem": "1",
+                "TOCLevel": "1",
+                "pagebreak": "0"
+            },
+            "HTML": "<h2>Mesh Size</h2>",
+            "skip_empty": 0
+        },
+        "sort_selection": "",
+        "parent": "Template_3",
+        "children": []
+    },
+    "Template_18": {
+        "name": "Mesh Quality",
+        "report_type": "Layout:basic",
+        "tags": "",
+        "item_filter": "A|i_type|cont|table;A|i_name|eq|MeshQualityTableItem;",
+        "params": {
+            "properties": {
+                "TOCItem": "1",
+                "TOCLevel": "1",
+                "pagebreak": "0"
+            },
+            "HTML": "<h2>Mesh Quality</h2>",
+            "skip_empty": 0
+        },
+        "sort_selection": "",
+        "parent": "Template_3",
+        "children": []
+    },
+    "Template_19": {
+        "name": "Orthogonal Quality",
+        "report_type": "Layout:basic",
+        "tags": "",
+        "item_filter": "A|i_type|eq|image;A|i_name|eq|MeshOrthogonalHistogram;",
+        "params": {
+            "properties": {
+                "TOCItem": "1",
+                "TOCLevel": "1",
+                "pagebreak": "0"
+            },
+            "HTML": "<h2>Orthogonal Quality</h2>",
+            "skip_empty": 0
+        },
+        "sort_selection": "",
+        "parent": "Template_3",
+        "children": []
+    },
+    "Template_4": {
+        "name": "Simulation Setup",
+        "report_type": "Layout:panel",
+        "tags": "",
+        "item_filter": "",
+        "params": {
+            "properties": {
+                "TOCItem": "1",
+                "TOCLevel": "0",
+                "panel_template_toggle": "1",
+                "pagebreak": "1"
+            },
+            "HTML": "<h2>Simulation Setup</h2>",
+            "skip_empty": 0
+        },
+        "sort_selection": "",
+        "parent": "Template_0",
+        "children": [
+            "Template_20",
+            "Template_21"
+        ]
+    },
+    "Template_20": {
+        "name": "Physics",
+        "report_type": "Layout:panel",
+        "tags": "",
+        "item_filter": "",
+        "params": {
+            "properties": {
+                "TOCItem": "1",
+                "TOCLevel": "1",
+                "panel_template_toggle": "1",
+                "pagebreak": "0"
+            },
+            "HTML": "<h2>Physics</h2>",
+            "skip_empty": 0
+        },
+        "sort_selection": "",
+        "parent": "Template_4",
+        "children": [
+            "Template_22",
+            "Template_23",
+            "Template_24",
+            "Template_25"
+        ]
+    },
+    "Template_22": {
+        "name": "Models",
+        "report_type": "Layout:basic",
+        "tags": "",
+        "item_filter": "A|i_type|eq|table;A|i_name|eq|ModelsTableItem;",
+        "params": {
+            "properties": {
+                "TOCItem": "1",
+                "TOCLevel": "2",
+                "pagebreak": "0"
+            },
+            "HTML": "<h2>Models</h2>",
+            "skip_empty": 0
+        },
+        "sort_selection": "",
+        "parent": "Template_20",
+        "children": []
+    },
+    "Template_23": {
+        "name": "Material Properties",
+        "report_type": "Layout:basic",
+        "tags": "",
+        "item_filter": "A|i_type|eq|tree;A|i_name|eq|MaterialsTreeItem;",
+        "params": {
+            "properties": {
+                "TOCItem": "1",
+                "TOCLevel": "2",
+                "pagebreak": "0"
+            },
+            "HTML": "<h2>Material Properties</h2>",
+            "skip_empty": 0
+        },
+        "sort_selection": "",
+        "parent": "Template_20",
+        "children": []
+    },
+    "Template_24": {
+        "name": "Boundary Conditions",
+        "report_type": "Layout:basic",
+        "tags": "",
+        "item_filter": "A|i_type|eq|tree;A|i_name|eq|BoundaryZonesTreeItem;",
+        "params": {
+            "properties": {
+                "TOCItem": "1",
+                "TOCLevel": "2",
+                "pagebreak": "0"
+            },
+            "HTML": "<h2>{{\"BoundaryZones\"|nexus_anchor}}Boundary Conditions</h2>",
+            "skip_empty": 0
+        },
+        "sort_selection": "",
+        "parent": "Template_20",
+        "children": []
+    },
+    "Template_25": {
+        "name": "Reference Values",
+        "report_type": "Layout:basic",
+        "tags": "",
+        "item_filter": "A|i_type|eq|table;A|i_name|eq|ReferenceValuesTableItem;",
+        "params": {
+            "properties": {
+                "TOCItem": "1",
+                "TOCLevel": "2",
+                "pagebreak": "0"
+            },
+            "HTML": "<h2>Reference Values</h2>",
+            "skip_empty": 0
+        },
+        "sort_selection": "",
+        "parent": "Template_20",
+        "children": []
+    },
+    "Template_21": {
+        "name": "Solver Settings",
+        "report_type": "Layout:basic",
+        "tags": "",
+        "item_filter": "A|i_type|eq|tree;A|i_name|eq|SolverSettingsTreeItem;",
+        "params": {
+            "properties": {
+                "TOCItem": "1",
+                "TOCLevel": "1",
+                "pagebreak": "0"
+            },
+            "HTML": "<h2>Solver Settings</h2>",
+            "skip_empty": 0
+        },
+        "sort_selection": "",
+        "parent": "Template_4",
+        "children": []
+    },
+    "Template_5": {
+        "name": "Run Information",
+        "report_type": "Layout:panel",
+        "tags": "",
+        "item_filter": "A|i_type|eq|table;A|i_name|eq|RunTableItem;",
+        "params": {
+            "properties": {
+                "TOCItem": "1",
+                "TOCLevel": "0",
+                "panel_template_toggle": "1",
+                "pagebreak": "1"
+            },
+            "HTML": "<h2>Run Information</h2>",
+            "skip_empty": 0
+        },
+        "sort_selection": "",
+        "parent": "Template_0",
+        "children": []
+    },
+    "Template_6": {
+        "name": "Solution Status",
+        "report_type": "Layout:panel",
+        "tags": "",
+        "item_filter": "A|i_type|eq|table;A|i_name|eq|SolverStatusTableItem;",
+        "params": {
+            "properties": {
+                "TOCItem": "1",
+                "TOCLevel": "0",
+                "panel_template_toggle": "1",
+                "pagebreak": "1"
+            },
+            "HTML": "<h2>Solution Status</h2><br /><br /><h4>Iterations: 10</h4>",
+            "skip_empty": 0
+        },
+        "sort_selection": "",
+        "parent": "Template_0",
+        "children": []
+    },
+    "Template_7": {
+        "name": "Plots",
+        "report_type": "Layout:panel",
+        "tags": "",
+        "item_filter": "",
+        "params": {
+            "properties": {
+                "TOCItem": "1",
+                "TOCLevel": "0",
+                "panel_template_toggle": "1",
+                "pagebreak": "1"
+            },
+            "HTML": "<h2>Plots</h2>",
+            "skip_empty": 0
+        },
+        "sort_selection": "",
+        "parent": "Template_0",
+        "children": [
+            "Template_26"
+        ]
+    },
+    "Template_26": {
+        "name": "PlotTabs",
+        "report_type": "Layout:tabs",
+        "tags": "",
+        "item_filter": "",
+        "params": {
+            "properties": {
+                "TOCItem": "0",
+                "pagebreak": "0"
+            },
+            "skip_empty": 0
+        },
+        "sort_selection": "",
+        "parent": "Template_7",
+        "children": [
+            "Template_27"
+        ]
+    },
+    "Template_27": {
+        "name": "Residuals",
+        "report_type": "Layout:basic",
+        "tags": "",
+        "item_filter": "A|i_type|cont|table;A|i_name|eq|residuals_plot;",
+        "params": {
+            "properties": {
+                "TOCItem": "0",
+                "pagebreak": "0"
+            },
+            "HTML": "<h2>Residuals</h2>",
+            "skip_empty": 0
+        },
+        "sort_selection": "",
+        "parent": "Template_26",
+        "children": []
+    },
+    "Template_8": {
+        "name": "Mesh",
+        "report_type": "Layout:panel",
+        "tags": "",
+        "item_filter": "",
+        "params": {
+            "properties": {
+                "TOCItem": "1",
+                "TOCLevel": "0",
+                "panel_template_toggle": "1",
+                "pagebreak": "1"
+            },
+            "HTML": "<h2>Mesh</h2>",
+            "skip_empty": 0
+        },
+        "sort_selection": "",
+        "parent": "Template_0",
+        "children": [
+            "Template_28"
+        ]
+    },
+    "Template_28": {
+        "name": "MeshTabs",
+        "report_type": "Layout:tabs",
+        "tags": "",
+        "item_filter": "",
+        "params": {
+            "properties": {
+                "TOCItem": "0",
+                "pagebreak": "0"
+            },
+            "skip_empty": 0
+        },
+        "sort_selection": "",
+        "parent": "Template_8",
+        "children": [
+            "Template_29"
+        ]
+    },
+    "Template_29": {
+        "name": "mesh1",
+        "report_type": "Layout:basic",
+        "tags": "",
+        "item_filter": "A|i_type|cont|image;A|i_name|eq|mesh1;",
+        "params": {
+            "properties": {
+                "TOCItem": "0",
+                "pagebreak": "0"
+            },
+            "HTML": "<h2>mesh-1</h2>",
+            "skip_empty": 0
+        },
+        "sort_selection": "",
+        "parent": "Template_28",
+        "children": []
+    },
+    "Template_9": {
+        "name": "Contours",
+        "report_type": "Layout:panel",
+        "tags": "",
+        "item_filter": "A|i_type|eq|image;A|i_name|cont|_contour;",
+        "params": {
+            "properties": {
+                "TOCItem": "1",
+                "TOCLevel": "0",
+                "panel_template_toggle": "1",
+                "pagebreak": "1"
+            },
+            "HTML": "<h2>Contours</h2>",
+            "skip_empty": 0
+        },
+        "sort_selection": "",
+        "parent": "Template_0",
+        "children": [
+            "Template_30"
+        ]
+    },
+    "Template_30": {
+        "name": "ContourTabs",
+        "report_type": "Layout:tabs",
+        "tags": "",
+        "item_filter": "",
+        "params": {
+            "properties": {
+                "TOCItem": "0",
+                "pagebreak": "0"
+            },
+            "skip_empty": 0
+        },
+        "sort_selection": "",
+        "parent": "Template_9",
+        "children": [
+            "Template_31",
+            "Template_32"
+        ]
+    },
+    "Template_31": {
+        "name": "contour-1",
+        "report_type": "Layout:basic",
+        "tags": "",
+        "item_filter": "A|i_type|cont|image;A|i_name|cont|contour-1;",
+        "params": {
+            "properties": {
+                "TOCItem": "0",
+                "pagebreak": "0"
+            },
+            "HTML": "<h2>contour-1</h2>",
+            "skip_empty": 0
+        },
+        "sort_selection": "",
+        "parent": "Template_30",
+        "children": []
+    },
+    "Template_32": {
+        "name": "contour-2",
+        "report_type": "Layout:basic",
+        "tags": "",
+        "item_filter": "A|i_type|cont|image;A|i_name|eq|contour-1;",
+        "params": {
+            "properties": {
+                "TOCItem": "0",
+                "pagebreak": "0"
+            },
+            "HTML": "<h2>temperature-contour</h2>",
+            "skip_empty": 0
+        },
+        "sort_selection": "",
+        "parent": "Template_30",
+        "children": []
+    },
+    "Template_10": {
+        "name": "Pathlines",
+        "report_type": "Layout:panel",
+        "tags": "",
+        "item_filter": "A|i_type|cont|image;A|i_name|cont|pathline;",
+        "params": {
+            "properties": {
+                "TOCItem": "1",
+                "TOCLevel": "0",
+                "panel_template_toggle": "1",
+                "pagebreak": "1"
+            },
+            "HTML": "<h2>Pathlines</h2>",
+            "skip_empty": 0
+        },
+        "sort_selection": "",
+        "parent": "Template_0",
+        "children": [
+            "Template_33"
+        ]
+    },
+    "Template_33": {
+        "name": "PathlineTabs",
+        "report_type": "Layout:tabs",
+        "tags": "",
+        "item_filter": "",
+        "params": {
+            "properties": {
+                "TOCItem": "0",
+                "pagebreak": "0"
+            },
+            "skip_empty": 0
+        },
+        "sort_selection": "",
+        "parent": "Template_10",
+        "children": [
+            "Template_34",
+            "Template_35"
+        ]
+    },
+    "Template_34": {
+        "name": "pathlines-1",
+        "report_type": "Layout:basic",
+        "tags": "",
+        "item_filter": "A|i_type|cont|image;A|i_name|eq|pathlines-1;",
+        "params": {
+            "properties": {
+                "TOCItem": "0",
+                "pagebreak": "0"
+            },
+            "HTML": "<h2>pathlines-1</h2>",
+            "skip_empty": 0
+        },
+        "sort_selection": "",
+        "parent": "Template_33",
+        "children": []
+    },
+    "Template_35": {
+        "name": "pathlines-2",
+        "report_type": "Layout:basic",
+        "tags": "",
+        "item_filter": "A|i_type|cont|image;A|i_name|eq|pathlines-2;",
+        "params": {
+            "properties": {
+                "TOCItem": "0",
+                "pagebreak": "0"
+            },
+            "HTML": "<h2>pathlines-1</h2>",
+            "skip_empty": 0
+        },
+        "sort_selection": "",
+        "parent": "Template_33",
+        "children": []
+    },
+    "Template_11": {
+        "name": "Scenes",
+        "report_type": "Layout:panel",
+        "tags": "",
+        "item_filter": "A|i_type|cont|scene;O|i_name|cont|_scene;",
+        "params": {
+            "properties": {
+                "TOCItem": "1",
+                "TOCLevel": "0",
+                "panel_template_toggle": "1",
+                "pagebreak": "1"
+            },
+            "HTML": "<h2>Scenes</h2>",
+            "skip_empty": 0
+        },
+        "sort_selection": "",
+        "parent": "Template_0",
+        "children": [
+            "Template_36"
+        ]
+    },
+    "Template_36": {
+        "name": "SceneTabs",
+        "report_type": "Layout:tabs",
+        "tags": "",
+        "item_filter": "",
+        "params": {
+            "properties": {
+                "TOCItem": "0",
+                "pagebreak": "0"
+            },
+            "skip_empty": 0
+        },
+        "sort_selection": "",
+        "parent": "Template_11",
+        "children": [
+            "Template_37",
+            "Template_38"
+        ]
+    },
+    "Template_37": {
+        "name": "scene-1(3D)",
+        "report_type": "Layout:basic",
+        "tags": "",
+        "item_filter": "A|i_type|eq|scene;A|i_name|cont|scene-1;",
+        "params": {
+            "properties": {
+                "TOCItem": "0",
+                "pagebreak": "0",
+                "width": 960,
+                "height": 720
+            },
+            "HTML": "<h2>scene-1</h2>",
+            "skip_empty": 0
+        },
+        "sort_selection": "",
+        "parent": "Template_36",
+        "children": []
+    },
+    "Template_38": {
+        "name": "scene-2(3D)",
+        "report_type": "Layout:basic",
+        "tags": "",
+        "item_filter": "A|i_type|cont|scene;A|i_name|cont|scene-2;",
+        "params": {
+            "properties": {
+                "TOCItem": "0",
+                "pagebreak": "0",
+                "width": 960,
+                "height": 720
+            },
+            "HTML": "<h2>scene-1</h2>",
+            "skip_empty": 0
+        },
+        "sort_selection": "",
+        "parent": "Template_36",
+        "children": []
+    },
+    "Template_12": {
+        "name": "Animations",
+        "report_type": "Layout:panel",
+        "tags": "",
+        "item_filter": "A|i_type|cont|anim;",
+        "params": {
+            "properties": {
+                "TOCItem": "1",
+                "TOCLevel": "0",
+                "panel_template_toggle": "1",
+                "pagebreak": "1"
+            },
+            "HTML": "<h2>Animations</h2>",
+            "skip_empty": 0
+        },
+        "sort_selection": "",
+        "parent": "Template_0",
+        "children": [
+            "Template_39"
+        ]
+    },
+    "Template_39": {
+        "name": "AnimationTabs",
+        "report_type": "Layout:tabs",
+        "tags": "",
+        "item_filter": "",
+        "params": {
+            "properties": {
+                "TOCItem": "0",
+                "pagebreak": "0"
+            },
+            "skip_empty": 0
+        },
+        "sort_selection": "",
+        "parent": "Template_12",
+        "children": [
+            "Template_40",
+            "Template_41"
+        ]
+    },
+    "Template_40": {
+        "name": "animation-1",
+        "report_type": "Layout:basic",
+        "tags": "",
+        "item_filter": "A|i_type|cont|anim;A|i_name|cont|animation-1;",
+        "params": {
+            "properties": {
+                "TOCItem": "0",
+                "pagebreak": "0"
+            },
+            "HTML": "<h2>animation-1</h2>",
+            "skip_empty": 0
+        },
+        "sort_selection": "",
+        "parent": "Template_39",
+        "children": []
+    },
+    "Template_41": {
+        "name": "animation-2",
+        "report_type": "Layout:basic",
+        "tags": "",
+        "item_filter": "A|i_type|cont|anim;A|i_name|cont|animation-2;",
+        "params": {
+            "properties": {
+                "TOCItem": "0",
+                "pagebreak": "0"
+            },
+            "HTML": "<h2>animation-1</h2>",
+            "skip_empty": 0
+        },
+        "sort_selection": "",
+        "parent": "Template_39",
+        "children": []
+    }
+}


### PR DESCRIPTION
Add a directory where to store .json files for default report templates.
Currently 4 default reports: single simulation report, FEA report, comparison report, and a simple PPTX report.

To follow: files that describe how to use each one of them (once the feature is available on ADO's side).