### PR TITLE
fix(doc): remove outdated `navbar_end` options in `conf.py`

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -68,7 +68,6 @@ html_theme_options = {
         "json_url": f"https://{cname}/versions.json",
         "version_match": switcher_version,
     },
-    "navbar_end": ["version-switcher", "theme-switcher", "navbar-icon-links"],
     "github_url": "https://github.com/ansys/pydynamicreporting/",
     "show_prev_next": False,
     "show_breadcrumbs": True,


### PR DESCRIPTION
This pull request intended to remove the outdated navigation end bar configuration. This ensures search bar renders correctly