### PR TITLE
Added Validation Checks on Set Payload Functions 

### DIFF
--- a/src/ansys/dynamicreporting/core/utils/report_objects.py
+++ b/src/ansys/dynamicreporting/core/utils/report_objects.py
@@ -1369,7 +1369,7 @@ class ItemREST(BaseRESTObject):
         self.fileobj = io.BytesIO(self.image_data)
         self.fileurl = "image.png"
 
-    def validate_file(input_path, description):
+    def validate_file(self, input_path, description):
         if not isinstance(input_path, str):
             raise TypeError(f"The input must be a string representing the file path.")
         

--- a/src/ansys/dynamicreporting/core/utils/report_objects.py
+++ b/src/ansys/dynamicreporting/core/utils/report_objects.py
@@ -17,7 +17,6 @@ import dateutil
 import dateutil.parser
 import pytz
 from pathlib import Path
-from ..serverless.item import HTMLParser
 from . import extremely_ugly_hacks, report_utils
 from .encoders import PayloaddataEncoder
 
@@ -1105,9 +1104,6 @@ class ItemREST(BaseRESTObject):
             s.encode("utf-8")
         except UnicodeEncodeError:
             raise ValueError("HTML content must be a valid UTF-8 string.")
-        
-        if not HTMLParser().validate(s):
-            raise ValueError("Expected content to contain valid HTML")
         
         self.type = ItemREST.type_html
         self._payloaddata = s


### PR DESCRIPTION
This PR introduces input validation for the `set_payload` functions. These functions previously lacked checks, leading to unexpected behavior when given incorrect input types or formats.

**Key updates:**

String and HTML payloads: Now validated to ensure input is a non-empty, non-whitespace UTF-8 encoded string.

File payloads: Validated to ensure the input is a string path that exists, points to a file, is not empty, and has a supported file extension based on payload type (e.g., .mp4 for animations, .avz, .glb for scenes).