### PR TITLE
Remove Restriction on Empty Table Payloads

### DIFF
--- a/src/ansys/dynamicreporting/core/utils/report_objects.py
+++ b/src/ansys/dynamicreporting/core/utils/report_objects.py
@@ -1235,9 +1235,6 @@ class ItemREST(BaseRESTObject):
         shape = array.shape
         size = array.size
 
-        if size == 0:
-            raise ValueError("Table array must not be empty.")
-
         nrows = 0
         ncols = 0
         # labels

--- a/tests/test_report_objects.py
+++ b/tests/test_report_objects.py
@@ -233,23 +233,19 @@ def test_category() -> None:
 @pytest.mark.ado_test
 def test_table_payload_item() -> None:
     a = ro.ItemREST()
-    succ1 = succ2 = succ3 = False
-    try:
-        a.set_payload_table_values([[]])
-    except ValueError as e:
-        succ1 = "Table array must not be empty." in str(e)
+    succ1 = succ2 = False
 
     try:
         a.set_payload_table_values([[1.0]], rowlbls=["Row 1", "Row 2"], collbls=["Column 1"])
     except ValueError as e:
-        succ2 = "Number of row labels does not match number of rows in the array." in str(e)
+        succ1 = "Number of row labels does not match number of rows in the array." in str(e)
 
     try:
         a.set_payload_table_values([[1.0]], rowlbls=["Row 1"], collbls=["Column 1", "Column 2"])
     except ValueError as e:
-        succ3 = "Number of column labels does not match number of columns in the array." in str(e)
+        succ2 = "Number of column labels does not match number of columns in the array." in str(e)
 
-    assert succ1 and succ2 and succ3
+    assert succ1 and succ2
 
 
 @pytest.mark.ado_test


### PR DESCRIPTION
This is a quick follow-up to the previous PR. There are scenarios (scripts and certain use cases), where it’s valid for empty tables to be included as payload items. To accommodate this, I’ve removed the earlier validation check that rejected empty tables. 

Additionally, the corresponding test case that enforced this validation has been removed.