### PR TITLE
remove explicit calls to PyQt5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
     "scipy<=1.15.3",  # breaks ADR if not included. Remove when statsmodels is updated
     "docutils>=0.21",
     "psycopg[binary]>=3.2.3",
+    "qtpy>=2.4.3"
 ]
 
 [tool.setuptools.packages.find]

--- a/src/ansys/dynamicreporting/core/utils/report_download_pdf.py
+++ b/src/ansys/dynamicreporting/core/utils/report_download_pdf.py
@@ -2,11 +2,11 @@ from functools import partial
 import os
 
 try:
-    from PyQt5 import QtCore, QtGui, QtWebEngineWidgets
+    from qtpy import QtCore, QtGui, QtWebEngineWidgets
 
     # Classes for saving PDF representation
     # pagedef = {width}X{height}X{0=port|1=land}X{left}X{right}X{top}X{bottom} all in mm
-    from PyQt5.QtCore import QTimer
+    from qtpy.QtCore import QTimer
 
     has_qt = True
 except Exception:

--- a/src/ansys/dynamicreporting/core/utils/report_objects.py
+++ b/src/ansys/dynamicreporting/core/utils/report_objects.py
@@ -22,7 +22,7 @@ from . import extremely_ugly_hacks, report_utils
 from .encoders import PayloaddataEncoder
 
 try:
-    from PyQt5 import QtCore, QtGui
+    from qtpy import QtCore, QtGui
 
     has_qt = True
 except ImportError:

--- a/src/ansys/dynamicreporting/core/utils/report_remote_server.py
+++ b/src/ansys/dynamicreporting/core/utils/report_remote_server.py
@@ -3,7 +3,7 @@ import urllib
 from requests import JSONDecodeError
 
 try:
-    from PyQt5 import QtCore, QtGui, QtWidgets
+    from qtpy import QtCore, QtGui, QtWidgets
 
     has_qt = True
 except ImportError:


### PR DESCRIPTION
We are on the verge of moving from Qt5 to Qt6

As part of this effort, we need to remove all the explicit calls to PyQt5 and use the qtpy wrapper, which adapts to the underlying Qt environment