### PR TITLE
Handle string representations of list inputs for row and column labels

### DIFF
--- a/src/ansys/dynamicreporting/core/utils/report_objects.py
+++ b/src/ansys/dynamicreporting/core/utils/report_objects.py
@@ -1,3 +1,4 @@
+from ast import literal_eval
 import base64
 import copy
 import datetime
@@ -1256,9 +1257,18 @@ class ItemREST(BaseRESTObject):
         elif len(shape) != 2:
             raise ValueError("Table array must be 2D.")
 
-        if rowlbls and len(rowlbls) != array.shape[0]:
+        if rowlbls and isinstance(rowlbls, str):
+            if len(literal_eval(rowlbls)) != array.shape[0]:
+                raise ValueError("Number of row labels does not match number of rows in the array.")
+        elif rowlbls and len(rowlbls) != array.shape[0]:
             raise ValueError("Number of row labels does not match number of rows in the array.")
-        if collbls and len(collbls) != array.shape[1]:
+
+        if collbls and isinstance(collbls, str):
+            if len(literal_eval(collbls)) != array.shape[1]:
+                raise ValueError(
+                    "Number of column labels does not match number of columns in the array."
+                )
+        elif collbls and len(collbls) != array.shape[1]:
             raise ValueError(
                 "Number of column labels does not match number of columns in the array."
             )

--- a/src/ansys/dynamicreporting/core/utils/report_objects.py
+++ b/src/ansys/dynamicreporting/core/utils/report_objects.py
@@ -1262,17 +1262,8 @@ class ItemREST(BaseRESTObject):
         if not isinstance(collbls, (str, list)):
             raise TypeError("Column labels must be a string or a list.")
 
-        rows = []
-        if rowlbls and isinstance(rowlbls, str):
-            rows = literal_eval(rowlbls)
-        else:
-            rows = rowlbls
-
-        columns = []
-        if collbls and isinstance(collbls, str):
-            columns = literal_eval(collbls)
-        else:
-            columns = collbls
+        rows = literal_eval(rowlbls) if isinstance(rowlbls, str) else rowlbls
+        columns = literal_eval(collbls) if isinstance(collbls, str) else collbls
 
         if rows and len(rows) != array.shape[0]:
             raise ValueError("Number of row labels does not match number of rows in the array.")

--- a/src/ansys/dynamicreporting/core/utils/report_objects.py
+++ b/src/ansys/dynamicreporting/core/utils/report_objects.py
@@ -1262,12 +1262,13 @@ class ItemREST(BaseRESTObject):
         if not isinstance(collbls, (str, list)):
             raise TypeError("Column labels must be a string or a list.")
 
-        rows = columns = []
+        rows = []
         if rowlbls and isinstance(rowlbls, str):
             rows = literal_eval(rowlbls)
         else:
             rows = rowlbls
 
+        columns = []
         if collbls and isinstance(collbls, str):
             columns = literal_eval(collbls)
         else:

--- a/src/ansys/dynamicreporting/core/utils/report_objects.py
+++ b/src/ansys/dynamicreporting/core/utils/report_objects.py
@@ -1257,18 +1257,20 @@ class ItemREST(BaseRESTObject):
         elif len(shape) != 2:
             raise ValueError("Table array must be 2D.")
 
+        rows = columns = []
         if rowlbls and isinstance(rowlbls, str):
-            if len(literal_eval(rowlbls)) != array.shape[0]:
-                raise ValueError("Number of row labels does not match number of rows in the array.")
-        elif rowlbls and len(rowlbls) != array.shape[0]:
-            raise ValueError("Number of row labels does not match number of rows in the array.")
+            rows = literal_eval(rowlbls)
+        else:
+            rows = rowlbls
 
         if collbls and isinstance(collbls, str):
-            if len(literal_eval(collbls)) != array.shape[1]:
-                raise ValueError(
-                    "Number of column labels does not match number of columns in the array."
-                )
-        elif collbls and len(collbls) != array.shape[1]:
+            columns = literal_eval(collbls)
+        else:
+            columns = collbls
+
+        if rows and len(rows) != array.shape[0]:
+            raise ValueError("Number of row labels does not match number of rows in the array.")
+        if columns and len(columns) != array.shape[1]:
             raise ValueError(
                 "Number of column labels does not match number of columns in the array."
             )

--- a/src/ansys/dynamicreporting/core/utils/report_objects.py
+++ b/src/ansys/dynamicreporting/core/utils/report_objects.py
@@ -1257,9 +1257,9 @@ class ItemREST(BaseRESTObject):
         elif len(shape) != 2:
             raise ValueError("Table array must be 2D.")
 
-        if not isinstance(rowlbls, (str, list)):
+        if rowlbls and not isinstance(rowlbls, (str, list)):
             raise TypeError("Row labels must be a string or a list.")
-        if not isinstance(collbls, (str, list)):
+        if collbls and not isinstance(collbls, (str, list)):
             raise TypeError("Column labels must be a string or a list.")
 
         rows = literal_eval(rowlbls) if isinstance(rowlbls, str) else rowlbls

--- a/src/ansys/dynamicreporting/core/utils/report_objects.py
+++ b/src/ansys/dynamicreporting/core/utils/report_objects.py
@@ -1257,6 +1257,11 @@ class ItemREST(BaseRESTObject):
         elif len(shape) != 2:
             raise ValueError("Table array must be 2D.")
 
+        if not isinstance(rowlbls, (str, list)):
+            raise TypeError("Row labels must be a string or a list.")
+        if not isinstance(collbls, (str, list)):
+            raise TypeError("Column labels must be a string or a list.")
+
         rows = columns = []
         if rowlbls and isinstance(rowlbls, str):
             rows = literal_eval(rowlbls)


### PR DESCRIPTION
This update allows row and column labels to support both actual lists and string representations of lists (e.g. `'["A", "B", "C"]'`). If the input is a string that represents a list, it's now parsed and converted before performing type checks or further processing.