### PR TITLE
Reorder a template among its siblings in the Server ADR

### DIFF
--- a/src/ansys/dynamicreporting/core/utils/exceptions.py
+++ b/src/ansys/dynamicreporting/core/utils/exceptions.py
@@ -57,6 +57,14 @@ class TemplateEditorJSONLoadingError(RuntimeError):
     """Raised for errors when loading a JSON file for the template editor"""
 
 
+class TemplateNotExistError(RuntimeError):
+    """Raised when the template is not found"""
+
+
+class TemplateReorderOutOfBoundError(RuntimeError):
+    """Raised when a template is reordered to be out of the size of the siblings"""
+
+
 def raise_bad_request_error(response):
     """
     Generates bad request error message and raises an exception.

--- a/src/ansys/dynamicreporting/core/utils/report_remote_server.py
+++ b/src/ansys/dynamicreporting/core/utils/report_remote_server.py
@@ -856,6 +856,7 @@ class Server:
 
         parent.children.remove(template.guid)
         parent.children.insert(position, template.guid)
+        self.put_objects(parent)
 
     def create_item_category(self, name="New category"):
         """Create a new item category."""


### PR DESCRIPTION
User story in ADO: https://tfs.ansys.com:8443/tfs/ANSYS_Development/Portfolio/_boards/board/t/Nexus/Stories/?workitem=1234450

This PR fulfills the functionality of getting and setting orders of a target template in the server object level. Higher level wrapper can be in another PR after this PR is approved.

Testing is missing for now in case there will some design changes.