### PR TITLE
Rename input variable from x to value to match naming conventions

### DIFF
--- a/src/ansys/dynamicreporting/core/utils/report_objects.py
+++ b/src/ansys/dynamicreporting/core/utils/report_objects.py
@@ -2709,7 +2709,7 @@ class tablemapREST(GeneratorREST):
         name=None,
         output_name="output row",
         select_names="*",
-        operation="x",
+        operation="value",
     ):
         if name is None:
             name = ["*"]


### PR DESCRIPTION
Renamed the input variable from `x` to `value` in the operation parameter to align with naming conventions.

User Story: https://tfs.ansys.com:8443/tfs/ANSYS_Development/Portfolio/_workitems/edit/1289662

