### PR TITLE
Dark mode support on serverless ADR

### DIFF
--- a/doc/source/serverless/configuration.rst
+++ b/doc/source/serverless/configuration.rst
@@ -125,6 +125,21 @@ Advanced / Optional Variables
 - **CEI_NEXUS_ENABLE_ACLS**
   Enables per-category Access Control Lists (ACLs). Experimental and not recommended for general use.
 
+Client-Side Interactions
+--------
+
+Serverless ADR also allows modifying the configuration setup from the client-side interactions using JavaScript. 
+
+- Dark mode modification: Users can change the value of ``<html></html>`` element's attribute ``data-bs-theme`` to toggle between light/dark mode themes.
+
+.. code-block:: javascript
+
+    // toggle light mode (default)
+    document.documentElement.setAttribute('data-bs-theme','light');
+
+    // toggle dark mode
+    document.documentElement.setAttribute('data-bs-theme','dark');
+
 Usage Notes
 -----------
 
@@ -191,23 +206,7 @@ Examples
         static_url="/static/",
         debug=True,
     )
-    adr.setup(collect_static=True)
-
-Client-Side Interactions
---------
-
-Serverless ADR also allows modifying the configuration setup from the client-side interactions using JavaScript. 
-
-- Dark mode modification: Users can change the value of ``<html></html>`` element's attribute ``data-bs-theme`` to toggle between light/dark mode themes.
-
-.. code-block:: javascript
-
-    // toggle light mode (default)
-    document.documentElement.setAttribute('data-bs-theme','light');
-
-    // toggle dark mode
-    document.documentElement.setAttribute('data-bs-theme','dark');
-    
+    adr.setup(collect_static=True)  
 
 Troubleshooting
 ---------------

--- a/doc/source/serverless/configuration.rst
+++ b/doc/source/serverless/configuration.rst
@@ -193,6 +193,22 @@ Examples
     )
     adr.setup(collect_static=True)
 
+Client-Side Interactions
+--------
+
+Serverless ADR also allows modifying the configuration setup from the client-side interactions using JavaScript. 
+
+- Dark mode modification: Users can change the value of ``<html></html>`` element's attribute ``data-bs-theme`` to toggle between light/dark mode themes.
+
+.. code-block:: javascript
+
+    // toggle light mode (default)
+    document.documentElement.setAttribute('data-bs-theme','light');
+
+    // toggle dark mode
+    document.documentElement.setAttribute('data-bs-theme','dark');
+    
+
 Troubleshooting
 ---------------
 

--- a/doc/source/serverless/configuration.rst
+++ b/doc/source/serverless/configuration.rst
@@ -128,7 +128,7 @@ Advanced / Optional Variables
 Client-Side Interactions
 --------
 
-Serverless ADR also allows modifying the configuration setup from the client-side interactions using JavaScript. 
+Serverless ADR also allows modifying the configuration setup from the client-side interactions using JavaScript.
 
 - Dark mode modification: Users can change the value of ``<html></html>`` element's attribute ``data-bs-theme`` to toggle between light/dark mode themes.
 
@@ -206,7 +206,7 @@ Examples
         static_url="/static/",
         debug=True,
     )
-    adr.setup(collect_static=True)  
+    adr.setup(collect_static=True)
 
 Troubleshooting
 ---------------

--- a/doc/source/serverless/configuration.rst
+++ b/doc/source/serverless/configuration.rst
@@ -126,7 +126,7 @@ Advanced / Optional Variables
   Enables per-category Access Control Lists (ACLs). Experimental and not recommended for general use.
 
 Client-Side Interactions
---------
+------------------------
 
 Serverless ADR also allows modifying the configuration setup from the client-side interactions using JavaScript.
 


### PR DESCRIPTION
Adding documentation on using JavaScript to toggle dark/light mode theme in serverless ADR. (Besides report templates also supports MathJax & Plotly 2D/3D Plots theme changes.)