### PR TITLE
Rename "Operation" to "Function" in Table Map Generator for Clarity

### DIFF
--- a/src/ansys/dynamicreporting/core/utils/report_objects.py
+++ b/src/ansys/dynamicreporting/core/utils/report_objects.py
@@ -2742,7 +2742,7 @@ class tablemapREST(GeneratorREST):
         name=None,
         output_name="output row",
         select_names="*",
-        operation="value",
+        function="value",
     ):
         if name is None:
             name = ["*"]
@@ -2755,8 +2755,8 @@ class tablemapREST(GeneratorREST):
             raise ValueError("Error: output_name should be a string")
         if not isinstance(select_names, str):
             raise ValueError("Error: select_names should be a string")
-        if not isinstance(operation, str):
-            raise ValueError("Error: operation should be a string")
+        if not isinstance(function, str):
+            raise ValueError("Error: function should be a string")
 
         if "map_params" not in d:
             d["map_params"] = {}
@@ -2768,7 +2768,7 @@ class tablemapREST(GeneratorREST):
         new_source["source_rows"] = ", ".join(repr(x) for x in name)
         new_source["output_rows"] = output_name
         new_source["output_columns_select"] = select_names
-        new_source["operation"] = operation
+        new_source["function"] = function
         sources.append(new_source)
         d["map_params"]["operations"] = sources
         self.params = json.dumps(d)

--- a/tests/test_report_objects.py
+++ b/tests/test_report_objects.py
@@ -1273,9 +1273,9 @@ def test_tablemap_operation() -> None:
     except ValueError as e:
         assert "select_names should be a string" in str(e)
     try:
-        a.add_operation(operation=1)
+        a.add_operation(function=1)
     except ValueError as e:
-        assert "operation should be a string" in str(e)
+        assert "function should be a string" in str(e)
     a.add_operation(name=["a"])
     a.add_operation(name=["b"])
     assert len(a.get_operations()) == 3


### PR DESCRIPTION
Replace the word "Operation" with "Function". The change was made because:
-  "Operations" is already used to represent the entire configuration of a map. 
- The term "Function" is more accurate and descriptive, as it refers to the mathematical function applied to the row/column mapping.
- Aligns with ADR Core now