### PR TITLE
Modify tree validator

### DIFF
--- a/src/ansys/dynamicreporting/core/utils/report_objects.py
+++ b/src/ansys/dynamicreporting/core/utils/report_objects.py
@@ -1152,7 +1152,7 @@ class ItemREST(BaseRESTObject):
             if "children" in i:
                 ItemREST.validate_tree(i["children"])
             # validate tree value, only at the last level of the tree or if value is not empty
-            if len(i.get("children", [])) == 0 or i.get("value", "").strip():
+            if len(i.get("children", [])) == 0 or (i.get("value") or "").strip():
                 ItemREST.validate_tree_value(i["value"])
 
     def set_payload_tree(self, t):


### PR DESCRIPTION
When a tree has multiple levels, it is possible that a top node has "value" empty. That should be accepted.
Check for the validity of 'value' only if it's not empty, or if it's at the last level of the tree hierarchy.