### PR TITLE
Avoid eager serverless product imports

### DIFF
--- a/src/ansys/dynamicreporting/core/serverless/item.py
+++ b/src/ansys/dynamicreporting/core/serverless/item.py
@@ -69,13 +69,13 @@ class Session(BaseModel):
     date: datetime = field(compare=False, kw_only=True, default_factory=timezone.now)
     """Session creation timestamp, defaulting to the current time."""
 
-    hostname: str = field(compare=False, kw_only=True, default=str(platform.node()))
+    hostname: str = field(compare=False, kw_only=True, default_factory=platform.node)
     """Hostname where the session was created."""
 
     platform: str = field(
         compare=False,
         kw_only=True,
-        default=str(report_utils.enve_arch()),
+        default_factory=report_utils.enve_arch,
     )
     """Platform/architecture identifier (for example ``"win64"``)."""
 

--- a/src/ansys/dynamicreporting/core/utils/geofile_processing.py
+++ b/src/ansys/dynamicreporting/core/utils/geofile_processing.py
@@ -32,17 +32,16 @@ import io
 import os
 import platform
 import subprocess  # nosec B78 B603 B404
+import sys
 import typing
 import zipfile
 
 from django.conf import settings
 
-try:
-    is_enve = True
-    import enve
-    from reports.engine import TemplateEngine
-except Exception:
-    is_enve = False
+
+def _get_enve_module():
+    """Return the loaded ``enve`` module, if one already exists."""
+    return sys.modules.get("enve")
 
 
 def get_evsn_proxy_image(filename: str) -> bytearray | None:
@@ -216,8 +215,9 @@ def rebuild_3d_geometry(csf_file: str, unique_id: str = "", exec_basis: str = No
     if csf_ext.lower() != ".avz":  # pragma: no cover
         # convert the udrw file into a .avz file using the cei_apexXXX_udrw2avz command
         app = f"cei_apex{settings.CEI_APEX_SUFFIX}_udrw2avz"
-        if is_enve is True:
-            app = os.path.join(enve.home(), "bin", app)
+        enve_module = _get_enve_module()
+        if enve_module is not None:
+            app = os.path.join(enve_module.home(), "bin", app)
         else:
             if exec_basis:
                 app = os.path.join(exec_basis, "bin", app)

--- a/src/ansys/dynamicreporting/core/utils/report_utils.py
+++ b/src/ansys/dynamicreporting/core/utils/report_utils.py
@@ -38,14 +38,6 @@ from PIL.TiffTags import TAGS
 import requests
 
 try:
-    import ceiversion
-    import enve
-
-    has_enve = True
-except (ImportError, SystemError):
-    has_enve = False
-
-try:
     import numpy
 
     has_numpy = True
@@ -56,6 +48,45 @@ text_type = str
 """@package report_utils
 Methods that serve as a shim to the enve and ceiversion modules that may not be present
 """
+
+
+def _get_optional_module(name):
+    """Return a loaded optional product module without importing it."""
+    module = sys.modules.get(name)
+    if module is not None:
+        return module
+    return None
+
+
+def _get_enve_module():
+    """Return the loaded ``enve`` module, if one already exists."""
+    return _get_optional_module("enve")
+
+
+def _get_ceiversion_module():
+    """Return the loaded ``ceiversion`` module, if one already exists."""
+    return _get_optional_module("ceiversion")
+
+
+def __getattr__(name):
+    """Expose product-module compatibility shims lazily.
+
+    Importing serverless ADR should not opportunistically import product Python
+    extensions because mismatched product binaries can hang under a newer
+    interpreter. These attributes therefore reflect only modules that are
+    already loaded by the host process.
+    """
+    if name == "has_enve":
+        return _get_enve_module() is not None and _get_ceiversion_module() is not None
+    if name == "enve":
+        module = _get_enve_module()
+        if module is not None:
+            return module
+    if name == "ceiversion":
+        module = _get_ceiversion_module()
+        if module is not None:
+            return module
+    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
 
 
 def decode_url(s):
@@ -122,8 +153,9 @@ def is_enve_image_or_pil(img):
         True if the image can be opened either by PIL or enve
     """
     is_enve = False
-    if has_enve:  # pragma: no cover
-        is_enve = isinstance(img, enve.image)
+    enve_module = _get_enve_module()
+    if enve_module is not None:  # pragma: no cover
+        is_enve = isinstance(img, enve_module.image)
     is_PIL = check_if_PIL(img)
     return is_enve or is_PIL
 
@@ -285,8 +317,9 @@ def image_to_data(img):
     # 'format' = 'tif' or 'png'
     # 'file_data' = a byte array of the raw image (same content as disk file)
     data = None
-    if has_enve:  # pragma: no cover
-        if isinstance(img, enve.image):
+    enve_module = _get_enve_module()
+    if enve_module is not None:  # pragma: no cover
+        if isinstance(img, enve_module.image):
             data = dict(width=img.dims[0], height=img.dims[1])
             with tempfile.TemporaryDirectory() as temp_dir:
                 if img.enhanced:
@@ -314,21 +347,24 @@ def image_to_data(img):
 
 
 def enve_arch():
-    if has_enve:
-        return enve.arch()
+    enve_module = _get_enve_module()
+    if enve_module is not None:
+        return enve_module.arch()
     return platform.system().lower()
 
 
 def enve_home():
-    if has_enve:
-        return enve.home()
+    enve_module = _get_enve_module()
+    if enve_module is not None:
+        return enve_module.home()
     tmp = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
     return tmp
 
 
 def ceiversion_nexus_suffix():
-    if has_enve:
-        return ceiversion.nexus_suffix
+    ceiversion_module = _get_ceiversion_module()
+    if ceiversion_module is not None:
+        return ceiversion_module.nexus_suffix
     # If we are coming from pynexus, get the version from that
     try:
         from ansys.dynamicreporting.core import ansys_version
@@ -342,8 +378,9 @@ def ceiversion_nexus_suffix():
 
 
 def ceiversion_apex_suffix():
-    if has_enve:
-        return ceiversion.apex_suffix
+    ceiversion_module = _get_ceiversion_module()
+    if ceiversion_module is not None:
+        return ceiversion_module.apex_suffix
     # Note: at present the suffix strings are in lockstep and are expected
     # to stay that way.  So the Nexus suffix (easily found by the location
     # of this file) is a reasonable proxy for the apex suffix.
@@ -351,8 +388,9 @@ def ceiversion_apex_suffix():
 
 
 def ceiversion_ensight_suffix():
-    if has_enve:
-        return ceiversion.ensight_suffix
+    ceiversion_module = _get_ceiversion_module()
+    if ceiversion_module is not None:
+        return ceiversion_module.ensight_suffix
     # Note: at present the suffix strings are in lockstep and are expected
     # to stay that way.  So the Nexus suffix (easily found by the location
     # of this file) is a reasonable proxy for the ensight suffix as well.

--- a/tests/serverless/test_import_safety.py
+++ b/tests/serverless/test_import_safety.py
@@ -1,0 +1,67 @@
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import builtins
+from dataclasses import MISSING, fields
+import importlib
+import platform
+import sys
+
+import pytest
+
+
+def _block_product_imports(monkeypatch):
+    original_import = builtins.__import__
+
+    def guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name in {"ceiversion", "enve", "reports.engine"}:
+            raise AssertionError(f"Unexpected import during serverless module load: {name}")
+        if name == "reports" and "engine" in fromlist:
+            raise AssertionError("Unexpected import during serverless module load: reports.engine")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", guarded_import)
+
+
+@pytest.mark.ado_test
+def test_serverless_item_reload_does_not_import_product_modules(monkeypatch):
+    import ansys.dynamicreporting.core.serverless.item as item_module
+    import ansys.dynamicreporting.core.utils.geofile_processing as geofile_processing_module
+    import ansys.dynamicreporting.core.utils.report_utils as report_utils_module
+
+    for module_name in ("ceiversion", "enve", "reports.engine"):
+        monkeypatch.delitem(sys.modules, module_name, raising=False)
+
+    _block_product_imports(monkeypatch)
+
+    reloaded_report_utils = importlib.reload(report_utils_module)
+    importlib.reload(geofile_processing_module)
+    reloaded_item = importlib.reload(item_module)
+
+    session_fields = {field.name: field for field in fields(reloaded_item.Session)}
+
+    assert session_fields["hostname"].default is MISSING
+    assert session_fields["hostname"].default_factory is platform.node
+    assert session_fields["platform"].default is MISSING
+    assert session_fields["platform"].default_factory is reloaded_report_utils.enve_arch
+    assert reloaded_report_utils.has_enve is False
+    assert reloaded_report_utils.enve_arch() == platform.system().lower()


### PR DESCRIPTION
## What changed
This branch removes eager product-side imports from the serverless ADR import path and adds a regression test for that behavior.

- defer optional `enve` and `ceiversion` access in `report_utils` until runtime
- stop importing `enve` and `reports.engine` at module import time in `geofile_processing`
- make `Session` hostname and platform defaults lazy via `default_factory`
- add an import-safety regression test that reloads the serverless item path and asserts it does not import product modules

## Why
Importing `ansys.dynamicreporting.core.serverless` was pulling product Python modules during module import. On a newer host interpreter, that can hang before `ADR.setup()` ever runs. Deferring those lookups keeps the serverless surface import-safe while preserving the product-specific behavior when those modules are already present in-process.

## Impact
This is a targeted fix for Linux/Python 3.13 serverless import hangs and should not change normal runtime behavior beyond avoiding the eager probes.

## Validation
- `py_compile` on the touched modules and the new regression test
- isolated import-safety validation script using the repo's uv-managed Python
