### PR TITLE
expose bundled adr_metadata for serverless

### DIFF
--- a/src/ansys/dynamicreporting/core/serverless/adr.py
+++ b/src/ansys/dynamicreporting/core/serverless/adr.py
@@ -43,6 +43,7 @@ templates, and report exports.
 """
 
 import copy
+import importlib.util
 import json
 import os
 import platform
@@ -498,6 +499,45 @@ class ADR:
         if cls._instance is None or not cls._is_setup:
             raise RuntimeError("ADR has not been set up. Instantiate ADR first and call setup().")
 
+    def _iter_product_python_site_packages(self) -> Iterable[Path]:
+        """Yield product-bundled Python ``site-packages`` paths for this install."""
+        machine_root = self._ansys_installation / f"apex{self._ansys_version}" / "machines"
+        machine_name = "win64" if platform.system().lower().startswith("win") else "linux_2.6_64"
+        machine_dir = machine_root / machine_name
+        if not machine_dir.is_dir():
+            return
+
+        for python_root in sorted(machine_dir.glob("Python-*")):
+            candidates = [python_root / "Lib" / "site-packages"]
+            lib_dir = python_root / "lib"
+            if lib_dir.is_dir():
+                candidates.extend(sorted(lib_dir.glob("python*/site-packages")))
+
+            for candidate in candidates:
+                if candidate.is_dir():
+                    yield candidate
+
+    @staticmethod
+    def _contains_adr_metadata(site_packages: Path) -> bool:
+        """Return whether a ``site-packages`` directory exposes ``adr_metadata``."""
+        return (site_packages / "adr_metadata").is_dir() or (
+            site_packages / "adr_metadata.py"
+        ).is_file()
+
+    def _ensure_product_adr_metadata_on_path(self) -> None:
+        """Make product-bundled ``adr_metadata`` importable when ADR needs it."""
+        if importlib.util.find_spec("adr_metadata") is not None:
+            return
+
+        for site_packages in self._iter_product_python_site_packages():
+            if not self._contains_adr_metadata(site_packages):
+                continue
+
+            site_packages_path = str(site_packages)
+            if site_packages_path not in sys.path:
+                sys.path.append(site_packages_path)
+            return
+
     def setup(self, collect_static: bool = False) -> None:
         """Configure Django and perform ADR initialization.
 
@@ -612,6 +652,7 @@ class ADR:
                 self._ansys_installation / f"nexus{self._ansys_version}" / "django"
             ).resolve(strict=True)
             sys.path.append(str(adr_path))
+            self._ensure_product_adr_metadata_on_path()
             from ceireports import settings_serverless
         except (ImportError, OSError) as e:
             raise ImportError(f"Failed to import ADR from the Ansys installation: {e}")

--- a/tests/serverless/test_adr.py
+++ b/tests/serverless/test_adr.py
@@ -20,6 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import importlib.util
 from pathlib import Path
 from random import random as r
 import uuid
@@ -120,6 +121,84 @@ def test_get_database_config_after_setup(adr_serverless):
 def test_setup_after_setup(adr_serverless):
     with pytest.raises(RuntimeError):
         adr_serverless.setup(collect_static=True)
+
+
+def _adr_with_installation(install_dir: Path) -> ADR:
+    adr = object.__new__(ADR)
+    adr._ansys_installation = install_dir
+    adr._ansys_version = 271
+    return adr
+
+
+def _mock_missing_adr_metadata(monkeypatch):
+    original_find_spec = importlib.util.find_spec
+
+    def fake_find_spec(name, *args, **kwargs):
+        if name == "adr_metadata":
+            return None
+        return original_find_spec(name, *args, **kwargs)
+
+    monkeypatch.setattr(importlib.util, "find_spec", fake_find_spec)
+
+
+@pytest.mark.ado_test
+def test_ensure_product_adr_metadata_adds_linux_site_packages(tmp_path, monkeypatch):
+    from ansys.dynamicreporting.core.serverless import adr as adr_module
+
+    site_packages = (
+        tmp_path
+        / "ADR"
+        / "apex271"
+        / "machines"
+        / "linux_2.6_64"
+        / "Python-3.13.11"
+        / "lib"
+        / "python3.13"
+        / "site-packages"
+    )
+    (site_packages / "adr_metadata").mkdir(parents=True)
+    monkeypatch.setattr(adr_module.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(
+        adr_module.sys,
+        "path",
+        [entry for entry in adr_module.sys.path if entry != str(site_packages)],
+    )
+    _mock_missing_adr_metadata(monkeypatch)
+
+    adr = _adr_with_installation(tmp_path / "ADR")
+    adr._ensure_product_adr_metadata_on_path()
+
+    assert str(site_packages) in adr_module.sys.path
+
+
+@pytest.mark.ado_test
+def test_ensure_product_adr_metadata_skips_site_packages_without_module(tmp_path, monkeypatch):
+    from ansys.dynamicreporting.core.serverless import adr as adr_module
+
+    site_packages = (
+        tmp_path
+        / "ADR"
+        / "apex271"
+        / "machines"
+        / "linux_2.6_64"
+        / "Python-3.13.11"
+        / "lib"
+        / "python3.13"
+        / "site-packages"
+    )
+    site_packages.mkdir(parents=True)
+    monkeypatch.setattr(adr_module.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(
+        adr_module.sys,
+        "path",
+        [entry for entry in adr_module.sys.path if entry != str(site_packages)],
+    )
+    _mock_missing_adr_metadata(monkeypatch)
+
+    adr = _adr_with_installation(tmp_path / "ADR")
+    adr._ensure_product_adr_metadata_on_path()
+
+    assert str(site_packages) not in adr_module.sys.path
 
 
 @pytest.mark.ado_test


### PR DESCRIPTION
Serverless report rendering can enter ADR product animation code that imports adr_metadata. Product v271 places that module in the bundled apex Python site-packages path, which was not added by ADR.setup when running PyDynamicReporting from a separate Python environment.

Detect the product site-packages directory only when adr_metadata is otherwise unavailable, append it after existing sys.path entries, and cover the Linux package layout plus the no-module edge case.
