### PR TITLE
Keep cleanup failures from masking successful operations

### DIFF
--- a/src/ansys/dynamicreporting/core/adr_service.py
+++ b/src/ansys/dynamicreporting/core/adr_service.py
@@ -440,7 +440,12 @@ class Service:
                     try:
                         create_output = self._docker_launcher.create_nexus_db()
                     except Exception as e:  # pragma: no cover
-                        self._docker_launcher.cleanup()
+                        try:
+                            self._docker_launcher.cleanup()
+                        except Exception as cleanup_error:
+                            self.logger.warning(
+                                f"Failed to clean up Docker launcher: {cleanup_error}"
+                            )
                         self.logger.error(
                             "Error creating the database at the path {self._db_directory} in the "
                             f"Docker container.\nError: {str(e)}"
@@ -449,7 +454,12 @@ class Service:
                     for f in ["db.sqlite3", "view_report.nexdb"]:
                         db_file = os.path.join(self._db_directory, f)
                         if not os.path.isfile(db_file):
-                            self._docker_launcher.cleanup()
+                            try:
+                                self._docker_launcher.cleanup()
+                            except Exception as cleanup_error:
+                                self.logger.warning(
+                                    f"Failed to clean up Docker launcher: {cleanup_error}"
+                                )
                             self.logger.error(
                                 "Error creating the database using Docker at the path "
                                 + f"{self._db_directory}.\n"

--- a/src/ansys/dynamicreporting/core/docker_support.py
+++ b/src/ansys/dynamicreporting/core/docker_support.py
@@ -41,6 +41,7 @@ import random
 import re
 import string
 import tarfile
+from contextlib import suppress
 from pathlib import Path
 
 import docker
@@ -157,7 +158,8 @@ class DockerLauncher:
             with tarfile.open(tar_file_path) as tar:
                 tar.extractall(path=output_path)  # nosec B202
             # Remove the tar archive
-            tar_file_path.unlink()
+            with suppress(OSError):
+                tar_file_path.unlink()
         except Exception as e:
             raise RuntimeError(f"Can't copy files from container: {src}\n\n{str(e)}")
 

--- a/src/ansys/dynamicreporting/core/serverless/adr.py
+++ b/src/ansys/dynamicreporting/core/serverless/adr.py
@@ -243,9 +243,9 @@ class ADR:
                 }
             }
             # Ephemeral media/static directories.
-            tmp_media_dir = tempfile.TemporaryDirectory()
+            tmp_media_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
             self._media_directory = self._check_dir(Path(tmp_media_dir.name))
-            tmp_static_dir = tempfile.TemporaryDirectory()
+            tmp_static_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
             self._static_directory = self._check_dir(Path(tmp_static_dir.name))
             self._tmp_dirs.extend([tmp_media_dir, tmp_static_dir])
         else:
@@ -335,7 +335,7 @@ class ADR:
             # Copy installation from container to a local temp directory.
             # New Docker images use /Nexus/ADR, legacy images use /Nexus/CEI.
             # Try the new path first, then fall back to the legacy path.
-            tmp_install_dir = tempfile.TemporaryDirectory()
+            tmp_install_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
             self._tmp_dirs.append(tmp_install_dir)
             try:
                 docker_launcher.copy_to_host("/Nexus/ADR", dest=tmp_install_dir.name)
@@ -774,7 +774,10 @@ class ADR:
 
         # Clean up any TemporaryDirectory objects we created.
         for tmp_dir in self._tmp_dirs:
-            tmp_dir.cleanup()
+            try:
+                tmp_dir.cleanup()
+            except OSError:
+                self._logger.debug("Failed to clean up temporary ADR directory.", exc_info=True)
 
     def backup_database(
         self,
@@ -1430,6 +1433,7 @@ class ADR:
             with tempfile.TemporaryDirectory(
                 prefix="adr-browser-pdf-",
                 dir=scratch_root,
+                ignore_cleanup_errors=True,
             ) as tmp_dir:
                 tmp_path = Path(tmp_dir)
                 # Build the renderer first so invalid PDF options fail before the report render

--- a/src/ansys/dynamicreporting/core/serverless/item.py
+++ b/src/ansys/dynamicreporting/core/serverless/item.py
@@ -37,6 +37,7 @@ the serverless ADR API:
 
 from dataclasses import field
 from datetime import datetime
+from contextlib import suppress
 from html.parser import HTMLParser as BaseHTMLParser
 import io
 from pathlib import Path
@@ -299,7 +300,8 @@ class ImageContent(FileValidator):
                 raise ADRException("The enhanced image is empty")
             obj._enhanced = True
         obj._width, obj._height = image.size
-        image.close()
+        with suppress(OSError):
+            image.close()
         return file_str
 
 
@@ -888,7 +890,8 @@ class Image(FilePayloadMixin, Item):
                 raise ADRException(f"Error converting image to {self._file_ext}: {e}") from e
         else:  # save image as is (if enhanced or already PNG)
             self._save_file(self.file_path, img_bytes)
-        image.close()
+        with suppress(OSError):
+            image.close()
         super().save(**kwargs)
 
 

--- a/src/ansys/dynamicreporting/core/utils/filelock.py
+++ b/src/ansys/dynamicreporting/core/utils/filelock.py
@@ -336,7 +336,10 @@ class BaseFileLock:
         return None
 
     def __del__(self):
-        self.release(force=True)
+        try:
+            self.release(force=True)
+        except Exception:
+            logger.debug("Failed to release file lock during object finalization.", exc_info=True)
         return None
 
 

--- a/src/ansys/dynamicreporting/core/utils/pdf_renderer.py
+++ b/src/ansys/dynamicreporting/core/utils/pdf_renderer.py
@@ -562,10 +562,19 @@ class _BasePlaywrightPDFRenderer(ABC):
                 finally:
                     # Playwright recommends explicitly closing contexts created via
                     # browser.new_context() before browser.close() so their resources flush
-                    # gracefully. Guard the call because context creation itself can fail.
+                    # gracefully. Cleanup failures should not mask successful PDF bytes or the
+                    # original render failure.
                     if context is not None:
-                        context.close()
-                    browser.close()
+                        try:
+                            context.close()
+                        except Exception:
+                            self._logger.debug(
+                                "Failed to close Playwright browser context.", exc_info=True
+                            )
+                    try:
+                        browser.close()
+                    except Exception:
+                        self._logger.debug("Failed to close Playwright browser.", exc_info=True)
         except ADRException:
             raise
         except PlaywrightTimeoutError:

--- a/src/ansys/dynamicreporting/core/utils/report_objects.py
+++ b/src/ansys/dynamicreporting/core/utils/report_objects.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 from ast import literal_eval
 import base64
+from contextlib import suppress
 import copy
 import datetime
 import functools
@@ -1358,7 +1359,8 @@ class ItemREST(BaseRESTObject):
             buf = QtCore.QBuffer(be)
             buf.open(QtCore.QIODevice.WriteOnly)
             tmpimg.save(buf, "png")
-            buf.close()
+            with suppress(Exception):
+                buf.close()
             # s is an in-memory representation of a .png file
             # width and height are its size
             s = bytes(be)

--- a/src/ansys/dynamicreporting/core/utils/report_remote_server.py
+++ b/src/ansys/dynamicreporting/core/utils/report_remote_server.py
@@ -22,6 +22,7 @@
 
 import collections
 import configparser
+from contextlib import suppress
 import functools
 import hashlib
 from http.cookiejar import Cookie
@@ -751,6 +752,7 @@ class Server:
             progress.setMaximum(nobjs)
 
         for obj in copy_list:
+            fileobj = None
             try:
                 if progress:
                     progress.setValue(n)
@@ -761,20 +763,22 @@ class Server:
                 file_url = getattr(obj, "fileurl", None)
                 if file_url:
                     # need to pull the file from this url...
-                    obj.fileobj = tempfile.NamedTemporaryFile()
-                    if source.get_file(obj, obj.fileobj) != requests.codes.ok:
+                    fileobj = tempfile.NamedTemporaryFile()
+                    obj.fileobj = fileobj
+                    if source.get_file(obj, fileobj) != requests.codes.ok:
                         obj.fileobj = None
                 self.put_objects([obj])
-                # clean up temp file
-                fileobj = getattr(obj, "fileobj", None)
-                if fileobj:
-                    fileobj.close()
                 if type(obj) not in skip_count_types:
                     n += 1
             except Exception as e:
                 if print_allowed():
                     print(f"Failure while copying {obj}: {e}")
                 return False
+            finally:
+                # Temp payload cleanup should not report a failed copy after put_objects succeeds.
+                if fileobj:
+                    with suppress(OSError):
+                        fileobj.close()
         if progress:
             progress.setValue(nobjs)
         return True
@@ -2032,8 +2036,10 @@ def launch_local_database_server(
             pass
 
     # detach from stdout, stderr to avoid buffer blocking
-    monitor_process.stderr.close()
-    monitor_process.stdout.close()
+    for stream in (monitor_process.stderr, monitor_process.stdout):
+        if stream is not None:
+            with suppress(OSError):
+                stream.close()
 
     # Allow another API launch to continue
     if local_lock:

--- a/src/ansys/dynamicreporting/core/utils/report_utils.py
+++ b/src/ansys/dynamicreporting/core/utils/report_utils.py
@@ -22,6 +22,7 @@
 
 import array
 import base64
+from contextlib import suppress
 from html.parser import HTMLParser as BaseHTMLParser
 import io
 import json
@@ -103,7 +104,8 @@ def check_if_PIL(img):
         return False
     finally:
         if imghandle:
-            imghandle.close()
+            with suppress(OSError):
+                imghandle.close()
 
 
 def is_enve_image_or_pil(img):
@@ -227,7 +229,8 @@ def save_tif_stripped(pil_image, data, metadata):
     buff.seek(0)
     data["file_data"] = buff.read()
     data["format"] = "tif"
-    buff.close()
+    with suppress(OSError):
+        buff.close()
     return data
 
 
@@ -273,7 +276,8 @@ def PIL_image_to_data(img, guid=None):
         buff.seek(0)
         data["file_data"] = buff.read()
     if imghandle:
-        imghandle.close()
+        with suppress(OSError):
+            imghandle.close()
     return data
 
 
@@ -288,7 +292,7 @@ def image_to_data(img):
     if has_enve:  # pragma: no cover
         if isinstance(img, enve.image):
             data = dict(width=img.dims[0], height=img.dims[1])
-            with tempfile.TemporaryDirectory() as temp_dir:
+            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
                 if img.enhanced:
                     path = os.path.join(temp_dir, "enhanced_image.tif")
                     # Save the image as a tiff file (enhanced)
@@ -898,11 +902,13 @@ def find_unused_ports(
             continue
         # is anyone listening?
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        result = sock.connect_ex(("127.0.0.1", port))
+        try:
+            result = sock.connect_ex(("127.0.0.1", port))
+        finally:
+            with suppress(OSError):
+                sock.close()
         if result != 0:
             ports.append(port)
-        else:
-            sock.close()
         if len(ports) >= count:
             return ports
     # in case we failed...

--- a/tests/serverless/test_adr.py
+++ b/tests/serverless/test_adr.py
@@ -1599,6 +1599,97 @@ def test_export_report_as_browser_pdf_prefers_db_directory_for_scratch_files(
 
 
 @pytest.mark.ado_test
+def test_render_report_as_browser_pdf_ignores_temporary_directory_cleanup_error(
+    tmp_path, monkeypatch
+):
+    from ansys.dynamicreporting.core.serverless import ADR
+    from ansys.dynamicreporting.core.serverless import adr as adr_module
+    from ansys.dynamicreporting.core.serverless.html_exporter import (
+        ServerlessReportExporter,
+    )
+    from ansys.dynamicreporting.core.utils.pdf_renderer import (
+        _OfflinePlaywrightPDFRenderer,
+    )
+
+    db_directory = tmp_path / "db"
+    media_directory = tmp_path / "media"
+    static_directory = tmp_path / "static"
+    db_directory.mkdir()
+    media_directory.mkdir()
+    static_directory.mkdir()
+    captured: dict[str, object] = {}
+
+    class CleanupFailingTemporaryDirectory:
+        def __init__(self, *, prefix, dir, ignore_cleanup_errors=False):
+            captured["ignore_cleanup_errors"] = ignore_cleanup_errors
+            self._ignore_cleanup_errors = ignore_cleanup_errors
+            self.name = str(Path(dir) / f"{prefix}cleanup-error")
+
+        def __enter__(self):
+            Path(self.name).mkdir()
+            return self.name
+
+        def __exit__(self, exc_type, exc, traceback):
+            (Path(self.name) / "media").mkdir()
+            if not self._ignore_cleanup_errors:
+                raise OSError(39, "Directory not empty", str(Path(self.name) / "media"))
+            return False
+
+    class FakeTemplate:
+        def render(self, *, context=None, item_filter="", embed_scene_data=False, request=None):
+            return "<html><body><h1>Browser PDF cleanup error</h1></body></html>"
+
+    monkeypatch.setattr(adr_module.tempfile, "TemporaryDirectory", CleanupFailingTemporaryDirectory)
+    monkeypatch.setattr(
+        _OfflinePlaywrightPDFRenderer, "__init__", lambda self, *args, **kwargs: None
+    )
+    monkeypatch.setattr(ServerlessReportExporter, "export", lambda self: None)
+    monkeypatch.setattr(_OfflinePlaywrightPDFRenderer, "render_pdf", lambda self: b"%PDF-mock")
+
+    adr = object.__new__(ADR)
+    adr._db_directory = db_directory
+    adr._media_directory = media_directory
+    adr._static_directory = static_directory
+    adr._media_url = "/media/"
+    adr._static_url = "/static/"
+    adr._ansys_installation = tmp_path / "install"
+    adr._ansys_version = 271
+    adr._debug = False
+    adr._request = None
+    adr._logger = None
+
+    pdf_bytes = adr._render_template_as_browser_pdf(FakeTemplate())
+
+    assert pdf_bytes == b"%PDF-mock"
+    assert captured["ignore_cleanup_errors"] is True
+
+
+def test_close_ignores_temporary_directory_cleanup_error(monkeypatch):
+    from ansys.dynamicreporting.core.serverless import ADR
+    from ansys.dynamicreporting.core.serverless import adr as adr_module
+
+    cleanup_calls = []
+
+    class FakeTemporaryDirectory:
+        def cleanup(self):
+            cleanup_calls.append(self)
+            raise OSError("cleanup failed")
+
+    class FakeLogger:
+        def debug(self, *args, **kwargs):
+            return None
+
+    adr = object.__new__(ADR)
+    adr._tmp_dirs = [FakeTemporaryDirectory()]
+    adr._logger = FakeLogger()
+    monkeypatch.setattr(adr_module.connections, "close_all", lambda: None)
+
+    adr.close()
+
+    assert len(cleanup_calls) == 1
+
+
+@pytest.mark.ado_test
 def test_browser_pdf_scratch_root_falls_back_for_external_database(
     adr_serverless, tmp_path, monkeypatch
 ):

--- a/tests/serverless/test_pdf_renderer_cleanup.py
+++ b/tests/serverless/test_pdf_renderer_cleanup.py
@@ -1,0 +1,57 @@
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from unittest.mock import MagicMock
+from unittest.mock import Mock
+
+import pytest
+
+import ansys.dynamicreporting.core.utils.pdf_renderer as pdf_renderer_module
+from ansys.dynamicreporting.core.utils.pdf_renderer import _OfflinePlaywrightPDFRenderer
+
+
+@pytest.mark.unit
+def test_playwright_pdf_returns_bytes_when_browser_cleanup_fails(tmp_path, monkeypatch):
+    html_path = tmp_path / "index.html"
+    html_path.write_text("<html><body><p>Cleanup failure</p></body></html>", encoding="utf-8")
+    renderer = _OfflinePlaywrightPDFRenderer(html_dir=tmp_path)
+
+    page = Mock()
+    page.pdf.return_value = b"%PDF-mock"
+    context = Mock()
+    context.new_page.return_value = page
+    context.close.side_effect = RuntimeError("context close boom")
+    browser = Mock()
+    browser.new_context.return_value = context
+    browser.close.side_effect = RuntimeError("browser close boom")
+    playwright = Mock()
+    playwright.chromium.launch.return_value = browser
+    playwright_manager = MagicMock()
+    playwright_manager.__enter__.return_value = playwright
+
+    monkeypatch.setattr(pdf_renderer_module, "sync_playwright", lambda: playwright_manager)
+    monkeypatch.setattr(renderer, "_wait_for_render_ready", lambda page, deadline=None: None)
+    monkeypatch.setattr(renderer, "_compute_pdf_width", lambda page: None)
+
+    assert renderer.render_pdf() == b"%PDF-mock"
+    context.close.assert_called_once_with()
+    browser.close.assert_called_once_with()


### PR DESCRIPTION
## Summary
- Treat temporary-directory and resource-close failures as best-effort cleanup across browser PDF, serverless, Docker, and remote-copy paths.
- Preserve primary results and exceptions when cleanup fails after successful work.
- Add focused regression coverage for browser-PDF scratch cleanup, ADR temp-dir cleanup, and Playwright close failures.

## Test plan
- uv run pytest tests/serverless/test_adr.py::test_render_report_as_browser_pdf_ignores_temporary_directory_cleanup_error tests/serverless/test_adr.py::test_close_ignores_temporary_directory_cleanup_error tests/serverless/test_pdf_renderer_cleanup.py -q
- uv run pre-commit run --files src/ansys/dynamicreporting/core/adr_service.py src/ansys/dynamicreporting/core/docker_support.py src/ansys/dynamicreporting/core/serverless/adr.py src/ansys/dynamicreporting/core/serverless/item.py src/ansys/dynamicreporting/core/utils/filelock.py src/ansys/dynamicreporting/core/utils/pdf_renderer.py src/ansys/dynamicreporting/core/utils/report_objects.py src/ansys/dynamicreporting/core/utils/report_remote_server.py src/ansys/dynamicreporting/core/utils/report_utils.py tests/serverless/test_adr.py tests/serverless/test_pdf_renderer_cleanup.py
- make smoketest

Made with [Cursor](https://cursor.com)