### PR TITLE
fix: lazy-load optional Qt imports for service APIs

### DIFF
--- a/src/ansys/dynamicreporting/core/__init__.py
+++ b/src/ansys/dynamicreporting/core/__init__.py
@@ -63,4 +63,5 @@ def __getattr__(name):
 
         globals()[name] = Service
         return Service
+    # without this, module.some_typo returns None instead of failing
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/ansys/dynamicreporting/core/utils/report_download_pdf.py
+++ b/src/ansys/dynamicreporting/core/utils/report_download_pdf.py
@@ -20,31 +20,53 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import functools
 from functools import partial
 import os
 
-try:
-    from qtpy import QtCore, QtGui, QtWebEngineWidgets
+QtCore = None
+QtGui = None
+QtWebEngineWidgets = None
+QTimer = None
+has_qt = False
 
-    # Classes for saving PDF representation
-    # pagedef = {width}X{height}X{0=port|1=land}X{left}X{right}X{top}X{bottom} all in mm
-    from qtpy.QtCore import QTimer
 
+@functools.lru_cache(maxsize=1)
+def _load_qt():
+    """Load Qt PDF dependencies only when the PDF helper is actually requested."""
+    global QtCore, QtGui, QtWebEngineWidgets, QTimer, has_qt
+
+    try:
+        from qtpy import QtCore as imported_qtcore
+        from qtpy import QtGui as imported_qtgui
+        from qtpy import QtWebEngineWidgets as imported_qtwebenginewidgets
+        from qtpy.QtCore import QTimer as imported_qtimer
+    except Exception:
+        has_qt = False
+        return False
+
+    QtCore = imported_qtcore
+    QtGui = imported_qtgui
+    QtWebEngineWidgets = imported_qtwebenginewidgets
+    QTimer = imported_qtimer
     has_qt = True
-except Exception:
-    has_qt = False
+    return True
 
 
-if has_qt:  # pragma: no cover
+@functools.lru_cache(maxsize=1)
+def _load_qt_pdf_classes():
+    """Create Qt-backed PDF helper classes only when callers request them."""
+    if not _load_qt():
+        raise AttributeError("Qt PDF helpers are unavailable because Qt could not be imported.")
 
-    class NexusPDFPage(QtWebEngineWidgets.QWebEnginePage):
+    class NexusPDFPage(QtWebEngineWidgets.QWebEnginePage):  # pragma: no cover
         def __init__(self):
             super().__init__()
 
         def javaScriptConsoleMessage(self, level, message, line_number, source_id):
             pass
 
-    class NexusPDFSave:
+    class NexusPDFSave:  # pragma: no cover
         def __init__(self, app, parent=None):
             self._app = app
             self._parent = parent
@@ -144,3 +166,15 @@ if has_qt:  # pragma: no cover
             else:
                 self._result = "failure"
             self._pdf_filename = None
+
+    return NexusPDFPage, NexusPDFSave
+
+
+def __getattr__(name):
+    """Resolve Qt PDF helper classes only when a caller explicitly requests them."""
+    if name in {"NexusPDFPage", "NexusPDFSave"}:
+        nexus_pdf_page, nexus_pdf_save = _load_qt_pdf_classes()
+        globals()["NexusPDFPage"] = nexus_pdf_page
+        globals()["NexusPDFSave"] = nexus_pdf_save
+        return globals()[name]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/ansys/dynamicreporting/core/utils/report_objects.py
+++ b/src/ansys/dynamicreporting/core/utils/report_objects.py
@@ -48,12 +48,9 @@ from ..common_utils import check_dictionary_for_html
 from ..exceptions import TemplateDoesNotExist, TemplateReorderOutOfBounds
 from .encoders import PayloaddataEncoder
 
-try:
-    from qtpy import QtCore, QtGui
-
-    has_qt = True
-except ImportError:
-    has_qt = False
+QtCore = None
+QtGui = None
+has_qt = False
 
 try:
     import numpy
@@ -63,6 +60,24 @@ except ImportError:
     has_numpy = False
 
 logger = logging.getLogger(__name__)
+
+
+@functools.lru_cache(maxsize=1)
+def _load_qt():
+    """Load Qt image helpers only when callers actually need them."""
+    global QtCore, QtGui, has_qt
+
+    try:
+        from qtpy import QtCore as imported_qtcore
+        from qtpy import QtGui as imported_qtgui
+    except ImportError:
+        has_qt = False
+        return False
+
+    QtCore = imported_qtcore
+    QtGui = imported_qtgui
+    has_qt = True
+    return True
 
 
 def disable_warn_logging(func):
@@ -1329,7 +1344,7 @@ class ItemREST(BaseRESTObject):
         return value
 
     def set_payload_image(self, img):
-        if has_qt:  # pragma: no cover
+        if _load_qt():  # pragma: no cover
             if isinstance(img, QtGui.QImage):
                 tmpimg = img
             elif report_utils.is_enve_image_or_pil(img):

--- a/src/ansys/dynamicreporting/core/utils/report_remote_server.py
+++ b/src/ansys/dynamicreporting/core/utils/report_remote_server.py
@@ -47,13 +47,6 @@ from requests import JSONDecodeError
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
-try:
-    from qtpy import QtCore, QtGui, QtWidgets
-
-    has_qt = True
-except ImportError:
-    has_qt = False
-
 from . import exceptions, filelock, report_objects, report_utils
 from ..adr_utils import build_query_url
 from ..common_utils import populate_template
@@ -61,8 +54,33 @@ from ..constants import JSON_ATTR_KEYS
 from ..exceptions import ADRException
 from .encoders import BaseEncoder
 
+QtCore = None
+QtGui = None
+QtWidgets = None
+has_qt = False
+
 logger = logging.getLogger("ansys.dynamicreporting.core")
 logging.getLogger("urllib3.connectionpool").setLevel(logging.CRITICAL)
+
+
+@functools.lru_cache(maxsize=1)
+def _load_qt():
+    """Load the optional Qt stack only when a GUI-specific path needs it."""
+    global QtCore, QtGui, QtWidgets, has_qt
+
+    try:
+        from qtpy import QtCore as imported_qtcore
+        from qtpy import QtGui as imported_qtgui
+        from qtpy import QtWidgets as imported_qtwidgets
+    except ImportError:
+        has_qt = False
+        return False
+
+    QtCore = imported_qtcore
+    QtGui = imported_qtgui
+    QtWidgets = imported_qtwidgets
+    has_qt = True
+    return True
 
 
 def print_allowed():
@@ -742,7 +760,7 @@ class Server:
                 nobjs += 1
         n = 0
         if progress:
-            if progress_qt and has_qt:
+            if progress_qt and _load_qt():
                 s = QtWidgets.QApplication.translate("nexus", "Importing:")
                 s += report_utils.from_local_8bit(obj_type)
             else:
@@ -1159,7 +1177,7 @@ class Server:
         query["print"] = "pdf"
         url = self.build_url_with_query(report_guid, query, item_filter)
         file_path = os.path.abspath(file_name)
-        if has_qt and (parent is not None):
+        if parent is not None and _load_qt():
             from .report_download_pdf import NexusPDFSave
 
             app = QtGui.QGuiApplication.instance()
@@ -1363,7 +1381,7 @@ def create_new_local_database(
 ):
     """Create a new, empty sqlite database  If parent is not None, a QtGui will be
     used."""
-    if parent and has_qt:  # pragma: no cover
+    if parent and _load_qt():  # pragma: no cover
         title = QtWidgets.QApplication.translate(
             "nexus", "Select an empty folder to create the database in"
         )
@@ -1380,7 +1398,7 @@ def create_new_local_database(
         os.makedirs(db_dir)
     except OSError as e:
         if not os.path.isdir(db_dir):
-            if parent and has_qt:  # pragma: no cover
+            if parent and _load_qt():  # pragma: no cover
                 msg = QtWidgets.QApplication.translate(
                     "nexus", "The selected directory could not be accessed."
                 )
@@ -1401,7 +1419,7 @@ def create_new_local_database(
     if os.path.isdir(os.path.join(db_dir, "media")) or os.path.isfile(
         os.path.join(db_dir, "db.sqlite3")
     ):
-        if parent and has_qt:
+        if parent and _load_qt():
             msg = QtWidgets.QApplication.translate(
                 "nexus", "The selected directory already appears to have a database in it."
             )
@@ -1445,7 +1463,7 @@ def create_new_local_database(
             if srcdir not in sys.path:
                 sys.path.append(srcdir)
             error = False
-            if parent and has_qt:
+            if parent and _load_qt():
                 QtWidgets.QApplication.setOverrideCursor(QtGui.QCursor(QtCore.Qt.WaitCursor))
             try:
                 import django
@@ -1470,7 +1488,7 @@ def create_new_local_database(
             except Exception as e:
                 logger.debug(f"Warning: {str(e)}")
                 error = True
-            if parent and has_qt:
+            if parent and _load_qt():
                 QtWidgets.QApplication.restoreOverrideCursor()
             # Unset the environmental vars...
             os.environ.pop("CEI_NEXUS_SECRET_KEY")
@@ -1504,7 +1522,7 @@ def create_new_local_database(
             )
 
     except Exception as e:
-        if parent and has_qt:
+        if parent and _load_qt():
             msg = QtWidgets.QApplication.translate(
                 "nexus", "The creation of a new, local database failed with the error:"
             )
@@ -1525,7 +1543,7 @@ def create_new_local_database(
         return_info["directory"] = db_dir
         return True
 
-    if parent and has_qt:
+    if parent and _load_qt():
         msg = QtWidgets.QApplication.translate(
             "nexus", "A new Nexus database has been created in the folder:"
         )
@@ -1802,7 +1820,7 @@ def launch_local_database_server(
             return False
 
     # Handle the directory
-    if parent and has_qt:  # pragma: no cover
+    if parent and _load_qt():  # pragma: no cover
         # skip the directory prompt if directory is valid
         if no_directory_prompt:
             db_dir = os.path.abspath(directory)
@@ -1898,7 +1916,7 @@ def launch_local_database_server(
         # validate will throw exceptions or return a float.
         _ = tmp_server.validate()
         # if we have a valid version number, then do not start a server!!!
-        if parent and has_qt:
+        if parent and _load_qt():
             msg = QtWidgets.QApplication.translate(
                 "nexus",
                 "There appears to be a local Nexus server already running on that port.\nPlease stop that server first or select a different port.",
@@ -1920,7 +1938,7 @@ def launch_local_database_server(
         pass
 
     # Start the busy cursor
-    if parent and has_qt:
+    if parent and _load_qt():
         QtWidgets.QApplication.setOverrideCursor(QtGui.QCursor(QtCore.Qt.WaitCursor))
 
     # Here we run nexus_launcher with the following command line:
@@ -1969,7 +1987,7 @@ def launch_local_database_server(
     local_use_tray = not terminate_on_python_exit
     if use_system_tray is not None:
         local_use_tray = use_system_tray
-    if local_use_tray and parent and has_qt:
+    if local_use_tray and parent and _load_qt():
         command.extend(["--tray", "1"])
 
     # Capture stderr to leverage nexus_launcher CLI error checking.  Grabbing stdout as well, but not
@@ -1989,7 +2007,7 @@ def launch_local_database_server(
         monitor_process = subprocess.Popen(command, **params)  # nosec B78 B603
     except Exception as e:
         logger.debug(f"Warning: {str(e)}")
-        if parent and has_qt:
+        if parent and _load_qt():
             QtWidgets.QApplication.restoreOverrideCursor()
             msg = QtWidgets.QApplication.translate(
                 "nexus", "Launching a server for the selected local database failed. Error:"
@@ -2011,7 +2029,7 @@ def launch_local_database_server(
         monitor_alive = monitor_process.poll() is None
         # if we ran out of patience or the monitor process is dead, we have an error
         if ((time.time() - t0) > server_timeout) or (not monitor_alive):
-            if parent and has_qt:
+            if parent and _load_qt():
                 QtWidgets.QApplication.restoreOverrideCursor()
                 msg = QtWidgets.QApplication.translate(
                     "nexus", "Unable to connect to the launched local Nexus server."
@@ -2063,7 +2081,7 @@ def launch_local_database_server(
     if local_lock:
         local_lock.release()
 
-    if parent and has_qt:
+    if parent and _load_qt():
         QtWidgets.QApplication.restoreOverrideCursor()
         if verbose:
             hostname = settings.get("server_hostname", "127.0.0.1")

--- a/tests/test_lazy_qt_imports.py
+++ b/tests/test_lazy_qt_imports.py
@@ -27,7 +27,12 @@ import textwrap
 
 
 def _run_import_probe(source: str) -> dict[str, object]:
-    """Execute a small import probe in a fresh interpreter."""
+    """
+    Execute a small import probe in a fresh interpreter (must use a subprocess to start free from previous runs).
+    sys.executable uses the same Python interpreter as the test runner.
+    "-c" tells Python to execute the following source string
+    textwrap.dedent(source) removes indentation from the triple-quoted embedded script before execution.
+    """
     result = subprocess.run(
         [sys.executable, "-c", textwrap.dedent(source)],
         capture_output=True,

--- a/tests/test_lazy_qt_imports.py
+++ b/tests/test_lazy_qt_imports.py
@@ -66,6 +66,35 @@ def test_report_remote_server_import_stays_headless():
     }
 
 
+def test_report_download_pdf_module_import_stays_headless():
+    probe = _run_import_probe(
+        """
+        import json
+        import sys
+
+        import ansys.dynamicreporting.core.utils.report_download_pdf as report_download_pdf
+
+        print(
+            json.dumps(
+                {
+                    "module": report_download_pdf.__name__,
+                    "qtpy": "qtpy" in sys.modules,
+                    "PySide6": "PySide6" in sys.modules,
+                    "shiboken6": "shiboken6" in sys.modules,
+                }
+            )
+        )
+        """
+    )
+
+    assert probe == {
+        "module": "ansys.dynamicreporting.core.utils.report_download_pdf",
+        "qtpy": False,
+        "PySide6": False,
+        "shiboken6": False,
+    }
+
+
 def test_service_import_stays_headless_while_loading_service_modules():
     probe = _run_import_probe(
         """

--- a/tests/test_lazy_qt_imports.py
+++ b/tests/test_lazy_qt_imports.py
@@ -1,0 +1,103 @@
+# Copyright (C) 2023 - 2026 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import json
+import subprocess
+import sys
+import textwrap
+
+
+def _run_import_probe(source: str) -> dict[str, object]:
+    """Execute a small import probe in a fresh interpreter."""
+    result = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(source)],
+        capture_output=True,
+        check=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
+def test_report_remote_server_import_stays_headless():
+    probe = _run_import_probe(
+        """
+        import json
+        import sys
+
+        from ansys.dynamicreporting.core.utils import report_remote_server
+
+        print(
+            json.dumps(
+                {
+                    "module": report_remote_server.__name__,
+                    "qtpy": "qtpy" in sys.modules,
+                    "PySide6": "PySide6" in sys.modules,
+                    "shiboken6": "shiboken6" in sys.modules,
+                }
+            )
+        )
+        """
+    )
+
+    assert probe == {
+        "module": "ansys.dynamicreporting.core.utils.report_remote_server",
+        "qtpy": False,
+        "PySide6": False,
+        "shiboken6": False,
+    }
+
+
+def test_service_import_stays_headless_while_loading_service_modules():
+    probe = _run_import_probe(
+        """
+        import json
+        import sys
+
+        from ansys.dynamicreporting.core import Service
+
+        print(
+            json.dumps(
+                {
+                    "module": Service.__module__,
+                    "report_objects_loaded": (
+                        "ansys.dynamicreporting.core.utils.report_objects" in sys.modules
+                    ),
+                    "report_remote_server_loaded": (
+                        "ansys.dynamicreporting.core.utils.report_remote_server" in sys.modules
+                    ),
+                    "qtpy": "qtpy" in sys.modules,
+                    "PySide6": "PySide6" in sys.modules,
+                    "shiboken6": "shiboken6" in sys.modules,
+                }
+            )
+        )
+        """
+    )
+
+    assert probe == {
+        "module": "ansys.dynamicreporting.core.adr_service",
+        "report_objects_loaded": True,
+        "report_remote_server_loaded": True,
+        "qtpy": False,
+        "PySide6": False,
+        "shiboken6": False,
+    }


### PR DESCRIPTION
Fixes https://tfs.ansys.com:8443/tfs/ANSYS_Development/Portfolio/_workitems/edit/1464892

Defer qtpy imports inside the service-side utility modules so headless callers can import Service and report_remote_server without pulling in PySide6 or shiboken6. Add fresh-interpreter regression tests to guard the service and remote-server import paths against eager Qt loading.

[lazy_service_qt_imports_line_by_line.md](https://github.com/user-attachments/files/29826636/lazy_service_qt_imports_line_by_line.md)

