### PR TITLE
fix: keep runtime Qt paths headless

### DIFF
--- a/doc/source/lowlevelapi/DataItemObject.rst
+++ b/doc/source/lowlevelapi/DataItemObject.rst
@@ -125,13 +125,12 @@ Image Item
 **item.set_payload_image(image)**
 
 This method sets the item payload to an image. The argument can be one
-of three things: the binary representation of a .png file on disk as a
-string, a QImage object or an enve.image object. Examples are shown
-below:
+of several things: a file path, image bytes, a Pillow image object, an
+optional Qt ``QImage`` object, or an ``enve.image`` object. The headless
+paths (file path, bytes, and Pillow image) are preferred when you do not
+need Qt-specific behavior. Examples are shown below:
 
--  A string which is the binary data representation of the image. Note:
-   this is the only format supported in a Python interpreter that lacks
-   the PyQt and enve modules.
+-  The binary data representation of the image.
 
    .. code-block:: python
 
@@ -140,11 +139,21 @@ below:
       item.set_payload_image(img)
 
 
--  A Qt QImage object instance
+-  A Pillow image object.
 
    .. code-block:: python
 
-      from PyQt4 import QtGui
+      from PIL import Image
+
+      img = Image.open("example.png")
+      item.set_payload_image(img)
+
+
+-  A Qt ``QImage`` object instance when Qt is available.
+
+   .. code-block:: python
+
+      from qtpy import QtGui
 
       img = QtGui.QImage("example.png")
       item.set_payload_image(img)

--- a/src/ansys/dynamicreporting/core/utils/report_download_pdf.py
+++ b/src/ansys/dynamicreporting/core/utils/report_download_pdf.py
@@ -57,7 +57,7 @@ def _load_qt():
 def _load_nexus_pdf_page():
     """Create the Qt-backed PDF page helper only when callers request it."""
     if not _load_qt():
-        raise AttributeError("NexusPDFPage")
+        raise AttributeError("NexusPDFPage is unavailable because Qt could not be imported.")
 
     class NexusPDFPage(QtWebEngineWidgets.QWebEnginePage):  # pragma: no cover
         def __init__(self):
@@ -73,7 +73,7 @@ def _load_nexus_pdf_page():
 def _load_nexus_pdf_save():
     """Create the Qt-backed PDF save helper only when callers request it."""
     if not _load_qt():
-        raise AttributeError("NexusPDFSave")
+        raise AttributeError("NexusPDFSave is unavailable because Qt could not be imported.")
     nexus_pdf_page = _load_nexus_pdf_page()
 
     class NexusPDFSave:  # pragma: no cover

--- a/src/ansys/dynamicreporting/core/utils/report_download_pdf.py
+++ b/src/ansys/dynamicreporting/core/utils/report_download_pdf.py
@@ -41,7 +41,7 @@ def _load_qt():
         from qtpy import QtGui as imported_qtgui
         from qtpy import QtWebEngineWidgets as imported_qtwebenginewidgets
         from qtpy.QtCore import QTimer as imported_qtimer
-    except Exception:
+    except ImportError:
         has_qt = False
         return False
 
@@ -54,10 +54,10 @@ def _load_qt():
 
 
 @functools.lru_cache(maxsize=1)
-def _load_qt_pdf_classes():
-    """Create Qt-backed PDF helper classes only when callers request them."""
+def _load_nexus_pdf_page():
+    """Create the Qt-backed PDF page helper only when callers request it."""
     if not _load_qt():
-        raise AttributeError("Qt PDF helpers are unavailable because Qt could not be imported.")
+        raise AttributeError("NexusPDFPage")
 
     class NexusPDFPage(QtWebEngineWidgets.QWebEnginePage):  # pragma: no cover
         def __init__(self):
@@ -65,6 +65,16 @@ def _load_qt_pdf_classes():
 
         def javaScriptConsoleMessage(self, level, message, line_number, source_id):
             pass
+
+    return NexusPDFPage
+
+
+@functools.lru_cache(maxsize=1)
+def _load_nexus_pdf_save():
+    """Create the Qt-backed PDF save helper only when callers request it."""
+    if not _load_qt():
+        raise AttributeError("NexusPDFSave")
+    nexus_pdf_page = _load_nexus_pdf_page()
 
     class NexusPDFSave:  # pragma: no cover
         def __init__(self, app, parent=None):
@@ -103,7 +113,7 @@ def _load_qt_pdf_classes():
                 dpi = screen.logicalDotsPerInch()
                 in_per_mm = 0.0393701
                 self._web_engine_view = QtWebEngineWidgets.QWebEngineView(self._parent)
-                self._web_page = NexusPDFPage()
+                self._web_page = nexus_pdf_page()
                 self._web_engine_view.setPage(self._web_page)
                 self._web_page.loadFinished.connect(self.load_finished)
                 dx = self._page[0] * in_per_mm * dpi
@@ -167,14 +177,15 @@ def _load_qt_pdf_classes():
                 self._result = "failure"
             self._pdf_filename = None
 
-    return NexusPDFPage, NexusPDFSave
+    return NexusPDFSave
 
 
 def __getattr__(name):
     """Resolve Qt PDF helper classes only when a caller explicitly requests them."""
-    if name in {"NexusPDFPage", "NexusPDFSave"}:
-        nexus_pdf_page, nexus_pdf_save = _load_qt_pdf_classes()
-        globals()["NexusPDFPage"] = nexus_pdf_page
-        globals()["NexusPDFSave"] = nexus_pdf_save
+    if name == "NexusPDFPage":
+        globals()[name] = _load_nexus_pdf_page()
         return globals()[name]
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    if name == "NexusPDFSave":
+        globals()[name] = _load_nexus_pdf_save()
+        return globals()[name]
+    raise AttributeError(name)

--- a/src/ansys/dynamicreporting/core/utils/report_objects.py
+++ b/src/ansys/dynamicreporting/core/utils/report_objects.py
@@ -80,6 +80,15 @@ def _load_qt():
     return True
 
 
+def _is_qimage_input(img):
+    """Detect Qt QImage instances without importing Qt just for an isinstance check."""
+    qt_roots = {"PyQt5", "PyQt6", "PySide2", "PySide6", "qtpy"}
+    return any(
+        base.__name__ == "QImage" and base.__module__.split(".")[0] in qt_roots
+        for base in type(img).__mro__
+    )
+
+
 def disable_warn_logging(func):
     # Decorator to suppress harmless warning messages
     @functools.wraps(func)
@@ -1344,27 +1353,10 @@ class ItemREST(BaseRESTObject):
         return value
 
     def set_payload_image(self, img):
-        if _load_qt():  # pragma: no cover
-            if isinstance(img, QtGui.QImage):
-                tmpimg = img
-            elif report_utils.is_enve_image_or_pil(img):
-                image_data = report_utils.image_to_data(img)
-                if image_data is not None:
-                    self.width = image_data["width"]
-                    self.height = image_data["height"]
-                    self.type = ItemREST.type_img
-                    # set up the parameters for get_url_file(): self.fileurl and self.fileobj
-                    self.image_data = image_data["file_data"]
-                    self.fileobj = io.BytesIO(self.image_data)
-                    # The format might be png or tif, make sure the name the URL properly
-                    # or Nexus will generate the incorrect display code.
-                    self.fileurl = "image." + image_data["format"]
-                return
-            else:
-                import imghdr
-
-                fmt = imghdr.what("/dummy", img)
-                tmpimg = QtGui.QImage.fromData(img, fmt)
+        if _is_qimage_input(img):  # pragma: no cover
+            if not _load_qt():
+                raise TypeError("QImage payloads require Qt image support to be available.")
+            tmpimg = img
             # record the GUID in the image (watermark it)
             # note: the Qt PNG format supports text keys
             tmpimg.setText("CEI_NEXUS_GUID", str(self.guid))
@@ -1379,51 +1371,81 @@ class ItemREST(BaseRESTObject):
             s = bytes(be)
             width = tmpimg.width()
             height = tmpimg.height()
-        else:
-            try:
-                from . import png
-            except Exception as e:
-                logger.debug(f"Warning: {str(e)}.\n")
-                import png
-            try:
-                # we can only read png images as string content (not filename)
-                reader = png.Reader(io.BytesIO(img))
-                # parse the input file
-                pngobj = reader.read()
-                width = pngobj[3]["size"][0]
-                height = pngobj[3]["size"][1]
-                imgdata = list(pngobj[2])
-                # tag the data and write it back out...
-                writer = png.Writer(
-                    width=width,
-                    height=height,
-                    bitdepth=pngobj[3].get("bitdepth", 8),
-                    greyscale=pngobj[3].get("greyscale", False),
-                    alpha=pngobj[3].get("alpha", False),
-                    planes=pngobj[3].get("planes", None),
-                    palette=pngobj[3].get("palette", None),
-                )
-            except Exception as e:
-                logger.debug(f"Warning: {str(e)}.\n")
-                # enhanced images will fall into this case
-                data = report_utils.PIL_image_to_data(img)
-                self.width = data["width"]
-                self.height = data["height"]
-                writer = png.Writer(
-                    width=self.width,
-                    height=self.height,
-                )
-                imgdata = data["file_data"]
+            self.width = width
+            self.height = height
+            self.type = ItemREST.type_img
+            self.image_data = s
+            self.fileobj = io.BytesIO(self.image_data)
+            self.fileurl = "image.png"
+            return
+
+        # Prefer the shared Pillow/enve conversion path so byte inputs stay headless.
+        if report_utils.is_enve_image_or_pil(img):
+            image_data = report_utils.image_to_data(img, guid=self.guid)
+            if image_data is not None:
+                self.width = image_data["width"]
+                self.height = image_data["height"]
                 self.type = ItemREST.type_img
-                self.image_data = data["file_data"]
+                # set up the parameters for get_url_file(): self.fileurl and self.fileobj
+                self.image_data = image_data["file_data"]
                 self.fileobj = io.BytesIO(self.image_data)
-                self.fileurl = "image." + data["format"]
+                # The format might be png or tif, make sure the name the URL properly
+                # or Nexus will generate the incorrect display code.
+                self.fileurl = "image." + image_data["format"]
                 return
+
+        try:
+            from . import png
+        except Exception as e:
+            logger.debug(f"Warning: {str(e)}.\n")
+            import png
+        try:
+            # we can only read png images as string content (not filename)
+            reader = png.Reader(io.BytesIO(img))
+            # parse the input file
+            pngobj = reader.read()
+            width = pngobj[3]["size"][0]
+            height = pngobj[3]["size"][1]
+            imgdata = list(pngobj[2])
+            # tag the data and write it back out...
+            writer = png.Writer(
+                width=width,
+                height=height,
+                bitdepth=pngobj[3].get("bitdepth", 8),
+                greyscale=pngobj[3].get("greyscale", False),
+                alpha=pngobj[3].get("alpha", False),
+                planes=pngobj[3].get("planes", None),
+                palette=pngobj[3].get("palette", None),
+            )
             # TODO: current version does not support set_text()?
             # writer.set_text(dict(CEI_NEXUS_GUID=str(self.guid)))
             io_in = io.BytesIO()
             writer.write(io_in, imgdata)
             s = io_in.getvalue()
+        except Exception as e:
+            logger.debug(f"Warning: {str(e)}.\n")
+            if _load_qt():  # pragma: no cover
+                import imghdr
+
+                fmt = imghdr.what("/dummy", img)
+                tmpimg = QtGui.QImage.fromData(img, fmt)
+            else:
+                raise
+
+            # record the GUID in the image (watermark it)
+            # note: the Qt PNG format supports text keys
+            tmpimg.setText("CEI_NEXUS_GUID", str(self.guid))
+            # save it in PNG format in memory
+            be = QtCore.QByteArray()
+            buf = QtCore.QBuffer(be)
+            buf.open(QtCore.QIODevice.WriteOnly)
+            tmpimg.save(buf, "png")
+            buf.close()
+            # s is an in-memory representation of a .png file
+            # width and height are its size
+            s = bytes(be)
+            width = tmpimg.width()
+            height = tmpimg.height()
         # common options
         self.width = width
         self.height = height

--- a/src/ansys/dynamicreporting/core/utils/report_objects.py
+++ b/src/ansys/dynamicreporting/core/utils/report_objects.py
@@ -82,7 +82,7 @@ def _load_qt():
 
 def _is_qimage_input(img):
     """Detect Qt QImage instances without importing Qt just for an isinstance check."""
-    qt_roots = {"PyQt5", "PyQt6", "PySide2", "PySide6", "qtpy"}
+    qt_roots = {"PyQt4", "PyQt5", "PyQt6", "PySide2", "PySide6", "qtpy"}
     return any(
         base.__name__ == "QImage" and base.__module__.split(".")[0] in qt_roots
         for base in type(img).__mro__
@@ -1379,7 +1379,50 @@ class ItemREST(BaseRESTObject):
             self.fileurl = "image.png"
             return
 
-        # Prefer the shared Pillow/enve conversion path so byte inputs stay headless.
+        # Preserve the longstanding pure-Python PNG-bytes path before falling back to
+        # broader Pillow handling, so common byte payloads stay headless without changing
+        # their legacy conversion flow.
+        if isinstance(img, bytes):
+            try:
+                from . import png
+            except Exception as e:
+                logger.debug(f"Warning: {str(e)}.\n")
+                import png
+            try:
+                # we can only read png images as string content (not filename)
+                reader = png.Reader(io.BytesIO(img))
+                # parse the input file
+                pngobj = reader.read()
+                width = pngobj[3]["size"][0]
+                height = pngobj[3]["size"][1]
+                imgdata = list(pngobj[2])
+                # tag the data and write it back out...
+                writer = png.Writer(
+                    width=width,
+                    height=height,
+                    bitdepth=pngobj[3].get("bitdepth", 8),
+                    greyscale=pngobj[3].get("greyscale", False),
+                    alpha=pngobj[3].get("alpha", False),
+                    planes=pngobj[3].get("planes", None),
+                    palette=pngobj[3].get("palette", None),
+                )
+                io_in = io.BytesIO()
+                writer.write(io_in, imgdata)
+                s = report_utils.add_png_text_chunk(
+                    io_in.getvalue(), "CEI_NEXUS_GUID", str(self.guid)
+                )
+                self.width = width
+                self.height = height
+                self.type = ItemREST.type_img
+                self.image_data = s
+                self.fileobj = io.BytesIO(self.image_data)
+                self.fileurl = "image.png"
+                return
+            except Exception as e:
+                logger.debug(f"Warning: {str(e)}.\n")
+
+        # Prefer the shared Pillow/enve conversion path once the PNG-specific byte path
+        # has had a chance to handle legacy PNG uploads.
         if report_utils.is_enve_image_or_pil(img):
             image_data = report_utils.image_to_data(img, guid=self.guid)
             if image_data is not None:
@@ -1394,43 +1437,10 @@ class ItemREST(BaseRESTObject):
                 self.fileurl = "image." + image_data["format"]
                 return
 
-        try:
-            from . import png
-        except Exception as e:
-            logger.debug(f"Warning: {str(e)}.\n")
-            import png
-        try:
-            # we can only read png images as string content (not filename)
-            reader = png.Reader(io.BytesIO(img))
-            # parse the input file
-            pngobj = reader.read()
-            width = pngobj[3]["size"][0]
-            height = pngobj[3]["size"][1]
-            imgdata = list(pngobj[2])
-            # tag the data and write it back out...
-            writer = png.Writer(
-                width=width,
-                height=height,
-                bitdepth=pngobj[3].get("bitdepth", 8),
-                greyscale=pngobj[3].get("greyscale", False),
-                alpha=pngobj[3].get("alpha", False),
-                planes=pngobj[3].get("planes", None),
-                palette=pngobj[3].get("palette", None),
-            )
-            # TODO: current version does not support set_text()?
-            # writer.set_text(dict(CEI_NEXUS_GUID=str(self.guid)))
-            io_in = io.BytesIO()
-            writer.write(io_in, imgdata)
-            s = io_in.getvalue()
-        except Exception as e:
-            logger.debug(f"Warning: {str(e)}.\n")
-            if _load_qt():  # pragma: no cover
-                import imghdr
-
-                fmt = imghdr.what("/dummy", img)
-                tmpimg = QtGui.QImage.fromData(img, fmt)
-            else:
-                raise
+        if _load_qt():  # pragma: no cover
+            tmpimg = QtGui.QImage.fromData(img)
+            if tmpimg.isNull():
+                raise ValueError("Qt could not decode the provided image payload.")
 
             # record the GUID in the image (watermark it)
             # note: the Qt PNG format supports text keys
@@ -1446,14 +1456,19 @@ class ItemREST(BaseRESTObject):
             s = bytes(be)
             width = tmpimg.width()
             height = tmpimg.height()
-        # common options
-        self.width = width
-        self.height = height
-        self.type = ItemREST.type_img
-        # set up the parameters for get_url_file(): self.fileurl and self.fileobj
-        self.image_data = s
-        self.fileobj = io.BytesIO(self.image_data)
-        self.fileurl = "image.png"
+            # common options
+            self.width = width
+            self.height = height
+            self.type = ItemREST.type_img
+            # set up the parameters for get_url_file(): self.fileurl and self.fileobj
+            self.image_data = s
+            self.fileobj = io.BytesIO(self.image_data)
+            self.fileurl = "image.png"
+            return
+
+        raise TypeError(
+            "Image payloads must be bytes, a file path, a Pillow image, a QImage, or an enve.image."
+        )
 
     def validate_file(self, input_path, description, allowed_extensions=None):
         if not isinstance(input_path, str):

--- a/src/ansys/dynamicreporting/core/utils/report_remote_server.py
+++ b/src/ansys/dynamicreporting/core/utils/report_remote_server.py
@@ -1177,12 +1177,19 @@ class Server:
         query["print"] = "pdf"
         url = self.build_url_with_query(report_guid, query, item_filter)
         file_path = os.path.abspath(file_name)
+        if parent is not None and _load_qt():
+            from .report_download_pdf import NexusPDFSave
+
+            app = QtGui.QGuiApplication.instance()
+            worker = NexusPDFSave(app)
+            _ = worker.save_page_pdf(url, filename=file_path, page=page, delay=delay)
+            return
 
         # ok, there is a bug in the 3.7 implementation of subprocess where
         # args are not properly encoded under Windows.  To pass a URL, you
         # cannot use '?' and '&' chars.  So, we support base64 encodes
-        # of the URLs here.  This keeps PDF export out of the caller process, so
-        # report generation does not pull in Qt just because a GUI parent was supplied.
+        # of the URLs here.  Headless callers use this subprocess path so they do not
+        # pull Qt into the current process.
         url = report_utils.encode_url(url)
         cmd = ["report_save_pdf", url, file_path]
         if page is not None:

--- a/src/ansys/dynamicreporting/core/utils/report_remote_server.py
+++ b/src/ansys/dynamicreporting/core/utils/report_remote_server.py
@@ -669,7 +669,7 @@ class Server:
             n = 0
             if progress:
                 text = "Scanning datasets..."
-                if progress_qt:
+                if progress_qt and _load_qt():
                     text = QtWidgets.QApplication.translate("nexus", "Scanning datasets...")
                 progress.setLabelText(text)
                 progress.setMaximum(nobjs)
@@ -684,7 +684,7 @@ class Server:
             # now the associated sessions
             if progress:
                 text = "Scanning sessions..."
-                if progress_qt:
+                if progress_qt and _load_qt():
                     text = QtWidgets.QApplication.translate("nexus", "Scanning sessions...")
                 progress.setLabelText(text)
             for guid in session_set:
@@ -698,7 +698,7 @@ class Server:
             # get the selected templates
             if progress:
                 text = "Scanning templates..."
-                if progress_qt:
+                if progress_qt and _load_qt():
                     text = QtWidgets.QApplication.translate("nexus", "Scanning templates...")
                 progress.setLabelText(text)
             objs = source.get_objects(objtype=report_objects.TemplateREST, query=query)
@@ -1177,18 +1177,12 @@ class Server:
         query["print"] = "pdf"
         url = self.build_url_with_query(report_guid, query, item_filter)
         file_path = os.path.abspath(file_name)
-        if parent is not None and _load_qt():
-            from .report_download_pdf import NexusPDFSave
-
-            app = QtGui.QGuiApplication.instance()
-            worker = NexusPDFSave(app)
-            _ = worker.save_page_pdf(url, filename=file_path, page=page, delay=delay)
-            return
 
         # ok, there is a bug in the 3.7 implementation of subprocess where
         # args are not properly encoded under Windows.  To pass a URL, you
         # cannot use '?' and '&' chars.  So, we support base64 encodes
-        # of the URLs here...
+        # of the URLs here.  This keeps PDF export out of the caller process, so
+        # report generation does not pull in Qt just because a GUI parent was supplied.
         url = report_utils.encode_url(url)
         cmd = ["report_save_pdf", url, file_path]
         if page is not None:

--- a/src/ansys/dynamicreporting/core/utils/report_utils.py
+++ b/src/ansys/dynamicreporting/core/utils/report_utils.py
@@ -33,7 +33,7 @@ import sys
 import tempfile
 from typing import List, Optional
 
-from PIL import Image
+from PIL import Image, PngImagePlugin
 from PIL.TiffTags import TAGS
 import requests
 
@@ -84,6 +84,8 @@ def check_if_PIL(img):
     bool:
         True if the image can be opened by PIL
     """
+    if isinstance(img, Image.Image):
+        return True
     # Assume you are getting bytes.
     # If string, open it
     imghandle = None
@@ -92,6 +94,8 @@ def check_if_PIL(img):
         imghandle = open(img, "rb")
     elif isinstance(img, bytes):
         imgbytes = img
+    else:
+        return False
     try:
         # Check PIL can handle the img opening
         if imghandle:
@@ -249,17 +253,19 @@ def PIL_image_to_data(img, guid=None):
     """
     imgbytes = None
     imghandle = None
-    if isinstance(img, str):
+    if isinstance(img, Image.Image):
+        image = img
+    elif isinstance(img, str):
         imghandle = open(img, "rb")
     elif isinstance(img, bytes):
         imgbytes = img
     data = {}
-    image = None
     if imghandle:
         image = Image.open(imghandle)
     elif imgbytes:
         image = Image.open(io.BytesIO(imgbytes))
-    data["format"] = image.format.lower()
+    image_format = (image.format or "PNG").lower()
+    data["format"] = image_format
     if data["format"] == "tiff":
         data["format"] = "tif"
     data["width"] = image.width
@@ -269,15 +275,23 @@ def PIL_image_to_data(img, guid=None):
         data = save_tif_stripped(image, data, metadata)
     else:
         buff = io.BytesIO()
-        image.save(buff, "PNG")
+        png_metadata = None
+        if guid is not None:
+            png_metadata = PngImagePlugin.PngInfo()
+            png_metadata.add_text("CEI_NEXUS_GUID", str(guid))
+        if png_metadata is not None:
+            image.save(buff, "PNG", pnginfo=png_metadata)
+        else:
+            image.save(buff, "PNG")
         buff.seek(0)
+        data["format"] = "png"
         data["file_data"] = buff.read()
     if imghandle:
         imghandle.close()
     return data
 
 
-def image_to_data(img):
+def image_to_data(img, guid=None):
     # Convert enve image object into a dictionary of image data or None
     # The dictionary has the keys:
     # 'width' = x pixel count
@@ -306,11 +320,11 @@ def image_to_data(img):
                     if img.save(path) == 0:
                         try:
                             with open(path, "rb") as img_file:
-                                return PIL_image_to_data(img_file.read())
+                                return PIL_image_to_data(img_file.read(), guid=guid)
                         except OSError:
                             return None
     if not data:
-        return PIL_image_to_data(img)
+        return PIL_image_to_data(img, guid=guid)
 
 
 def enve_arch():

--- a/src/ansys/dynamicreporting/core/utils/report_utils.py
+++ b/src/ansys/dynamicreporting/core/utils/report_utils.py
@@ -32,6 +32,7 @@ import socket
 import sys
 import tempfile
 from typing import List, Optional
+import zlib
 
 from PIL import Image, PngImagePlugin
 from PIL.TiffTags import TAGS
@@ -235,6 +236,43 @@ def save_tif_stripped(pil_image, data, metadata):
     return data
 
 
+def add_png_text_chunk(png_bytes, key, value):
+    """Add a PNG ``tEXt`` chunk to an existing PNG byte stream."""
+    png_signature = b"\x89PNG\r\n\x1a\n"
+    if not png_bytes.startswith(png_signature):
+        return png_bytes
+
+    text_chunk_type = b"tEXt"
+    text_chunk_data = key.encode("latin-1") + b"\x00" + value.encode("latin-1")
+    text_chunk_crc = zlib.crc32(text_chunk_type + text_chunk_data) & 0xFFFFFFFF
+    text_chunk = (
+        len(text_chunk_data).to_bytes(4, "big")
+        + text_chunk_type
+        + text_chunk_data
+        + text_chunk_crc.to_bytes(4, "big")
+    )
+
+    rebuilt_png = bytearray(png_signature)
+    offset = len(png_signature)
+    inserted_text = False
+    while offset < len(png_bytes):
+        if offset + 8 > len(png_bytes):
+            return png_bytes
+        chunk_length = int.from_bytes(png_bytes[offset : offset + 4], "big")
+        chunk_end = offset + 12 + chunk_length
+        if chunk_end > len(png_bytes):
+            return png_bytes
+
+        chunk_type = png_bytes[offset + 4 : offset + 8]
+        if not inserted_text and chunk_type == b"IEND":
+            rebuilt_png.extend(text_chunk)
+            inserted_text = True
+        rebuilt_png.extend(png_bytes[offset:chunk_end])
+        offset = chunk_end
+
+    return bytes(rebuilt_png) if inserted_text else png_bytes
+
+
 def PIL_image_to_data(img, guid=None):
     """
     Convert the input image to a dictionary holding the data for the payload.
@@ -259,6 +297,10 @@ def PIL_image_to_data(img, guid=None):
         imghandle = open(img, "rb")
     elif isinstance(img, bytes):
         imgbytes = img
+    else:
+        raise TypeError(
+            "Image payloads must be bytes, a file path, a Pillow image, or an enve.image."
+        )
     data = {}
     if imghandle:
         image = Image.open(imghandle)

--- a/tests/test_lazy_qt_imports.py
+++ b/tests/test_lazy_qt_imports.py
@@ -135,3 +135,246 @@ def test_service_import_stays_headless_while_loading_service_modules():
         "PySide6": False,
         "shiboken6": False,
     }
+
+
+def test_set_payload_image_runtime_stays_headless_for_png_bytes():
+    probe = _run_import_probe(
+        """
+        import base64
+        import io
+        import json
+        import sys
+
+        from PIL import Image
+        from ansys.dynamicreporting.core.utils.report_objects import ItemREST
+
+        png_bytes = base64.b64decode(
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO7Z4XcAAAAASUVORK5CYII="
+        )
+        item = ItemREST()
+        item.set_payload_image(png_bytes)
+        image = Image.open(io.BytesIO(item.image_data))
+
+        print(
+            json.dumps(
+                {
+                    "qtpy": "qtpy" in sys.modules,
+                    "PySide6": "PySide6" in sys.modules,
+                    "shiboken6": "shiboken6" in sys.modules,
+                    "width": item.width,
+                    "height": item.height,
+                    "fileurl": item.fileurl,
+                    "guid": str(item.guid),
+                    "guid_text": image.text.get("CEI_NEXUS_GUID"),
+                }
+            )
+        )
+        """
+    )
+
+    assert probe["qtpy"] is False
+    assert probe["PySide6"] is False
+    assert probe["shiboken6"] is False
+    assert probe["width"] == 1
+    assert probe["height"] == 1
+    assert probe["fileurl"] == "image.png"
+    assert probe["guid_text"] == probe["guid"]
+
+
+def test_set_payload_image_runtime_stays_headless_for_pillow_image():
+    probe = _run_import_probe(
+        """
+        import io
+        import json
+        import sys
+
+        from PIL import Image
+        from ansys.dynamicreporting.core.utils.report_objects import ItemREST
+
+        item = ItemREST()
+        item.set_payload_image(Image.new("RGB", (2, 3), color="red"))
+        image = Image.open(io.BytesIO(item.image_data))
+
+        print(
+            json.dumps(
+                {
+                    "qtpy": "qtpy" in sys.modules,
+                    "PySide6": "PySide6" in sys.modules,
+                    "shiboken6": "shiboken6" in sys.modules,
+                    "width": item.width,
+                    "height": item.height,
+                    "fileurl": item.fileurl,
+                    "guid": str(item.guid),
+                    "guid_text": image.text.get("CEI_NEXUS_GUID"),
+                }
+            )
+        )
+        """
+    )
+
+    assert probe["qtpy"] is False
+    assert probe["PySide6"] is False
+    assert probe["shiboken6"] is False
+    assert probe["width"] == 2
+    assert probe["height"] == 3
+    assert probe["fileurl"] == "image.png"
+    assert probe["guid_text"] == probe["guid"]
+
+
+def test_qimage_like_payload_fails_cleanly_without_touching_qt():
+    probe = _run_import_probe(
+        """
+        import json
+        import sys
+
+        from ansys.dynamicreporting.core.utils.report_objects import ItemREST
+
+        QImage = type("QImage", (), {"__module__": "PySide6.QtGui"})
+        item = ItemREST()
+
+        try:
+            item.set_payload_image(QImage())
+        except Exception as exc:
+            print(
+                json.dumps(
+                    {
+                        "qtpy": "qtpy" in sys.modules,
+                        "PySide6": "PySide6" in sys.modules,
+                        "shiboken6": "shiboken6" in sys.modules,
+                        "exception_type": type(exc).__name__,
+                        "message": str(exc),
+                    }
+                )
+            )
+        else:
+            raise AssertionError("Expected QImage-like payload to fail without Qt support.")
+        """
+    )
+
+    assert probe == {
+        "qtpy": False,
+        "PySide6": False,
+        "shiboken6": False,
+        "exception_type": "TypeError",
+        "message": "QImage payloads require Qt image support to be available.",
+    }
+
+
+def test_copy_items_runtime_stays_headless_with_progress_qt_enabled():
+    probe = _run_import_probe(
+        """
+        import json
+        import sys
+
+        from ansys.dynamicreporting.core.utils import report_objects
+        from ansys.dynamicreporting.core.utils.report_remote_server import Server
+
+        class FakeSource:
+            def __init__(self):
+                self.dataset = report_objects.DatasetREST()
+                self.session = report_objects.SessionREST()
+                self.item = report_objects.ItemREST()
+                self.item.dataset = self.dataset.guid
+                self.item.session = self.session.guid
+
+            def get_objects(self, objtype=None, query=None):
+                return [self.item]
+
+            def get_object_from_guid(self, guid, objtype=None):
+                if objtype is report_objects.DatasetREST and guid == self.dataset.guid:
+                    return self.dataset
+                if objtype is report_objects.SessionREST and guid == self.session.guid:
+                    return self.session
+                return None
+
+        class FakeProgress:
+            def __init__(self):
+                self.labels = []
+
+            def setLabelText(self, text):
+                self.labels.append(text)
+
+            def setMaximum(self, value):
+                pass
+
+            def setValue(self, value):
+                pass
+
+            def wasCanceled(self):
+                return False
+
+        server = Server()
+        server.put_objects = lambda objects: 200
+        progress = FakeProgress()
+        success = server.copy_items(FakeSource(), obj_type="item", progress=progress, progress_qt=True)
+
+        print(
+            json.dumps(
+                {
+                    "qtpy": "qtpy" in sys.modules,
+                    "PySide6": "PySide6" in sys.modules,
+                    "shiboken6": "shiboken6" in sys.modules,
+                    "success": success,
+                    "labels": progress.labels,
+                }
+            )
+        )
+        """
+    )
+
+    assert probe == {
+        "qtpy": False,
+        "PySide6": False,
+        "shiboken6": False,
+        "success": True,
+        "labels": ["Scanning datasets...", "Scanning sessions...", "Importing: item"],
+    }
+
+
+def test_export_report_as_pdf_runtime_stays_headless_even_with_parent():
+    probe = _run_import_probe(
+        """
+        import json
+        import sys
+
+        from ansys.dynamicreporting.core.utils import report_remote_server
+        from ansys.dynamicreporting.core.utils.report_remote_server import Server
+
+        captured = {}
+
+        def fake_run_nexus_utility(cmd, use_software_gl=False, exec_basis=None, ansys_version=None):
+            captured["cmd"] = cmd
+            captured["use_software_gl"] = use_software_gl
+            captured["exec_basis"] = exec_basis
+            captured["ansys_version"] = ansys_version
+
+        report_remote_server.run_nexus_utility = fake_run_nexus_utility
+
+        server = Server(url="http://example.com")
+        server.build_url_with_query = lambda report_guid, query, item_filter=None: (
+            "http://example.com/reports/report_display/?view=test-guid&print=pdf"
+        )
+
+        server.export_report_as_pdf("test-guid", "out.pdf", parent=object())
+
+        print(
+            json.dumps(
+                {
+                    "qtpy": "qtpy" in sys.modules,
+                    "PySide6": "PySide6" in sys.modules,
+                    "shiboken6": "shiboken6" in sys.modules,
+                    "cmd": captured["cmd"],
+                    "use_software_gl": captured["use_software_gl"],
+                }
+            )
+        )
+        """
+    )
+
+    assert probe["qtpy"] is False
+    assert probe["PySide6"] is False
+    assert probe["shiboken6"] is False
+    assert probe["cmd"][0] == "report_save_pdf"
+    assert probe["cmd"][1].startswith("b64:")
+    assert probe["cmd"][2].endswith("out.pdf")
+    assert probe["use_software_gl"] is True


### PR DESCRIPTION
## Summary
- Prefer the shared Pillow/enve image conversion path in set_payload_image() so common runtime image uploads stay headless and only real QImage inputs load Qt.
- Keep the service PDF and copy-progress runtime paths out of Qt by default, while leaving the legacy Qt PDF helpers lazily available only on explicit access.
- Add fresh-interpreter regression tests for the runtime headless paths and update the low-level image docs to describe the headless-first behavior.

## Test plan
- [x] uv sync --frozen --all-extras
- [x] uv run pytest tests/test_lazy_qt_imports.py -q
- [x] uv run python tests/smoketest.py
- [x] uv lock --locked
- [ ] uv run pre-commit run --all-files (blocked on Windows by the Add License Headers hook failing with WinError 1314 while creating a symlink)