### PR TITLE
Fix for race condition at garbage collection

### DIFF
--- a/src/ansys/dynamicreporting/core/utils/report_remote_server.py
+++ b/src/ansys/dynamicreporting/core/utils/report_remote_server.py
@@ -2038,6 +2038,14 @@ def launch_local_database_server(
     monitor_process.stderr.close()
     monitor_process.stdout.close()
 
+    # On Windows, if terminate_on_python_exit is True, we take care of cleaning up in the atexit handler.
+    # If it is False, a race condition can appear as the garbage collector cleans up in random order.
+    # To prevent a spurious WinError 6 message from the race condition, set the monitor_process.returncode to 0.
+    # This prevents Popen.__del__ from calling _WaitForSingleObject on a potentially-closed handle
+    # during garbage collection finalization. The process still gets cleaned up correctly.
+    if not terminate_on_python_exit:
+        monitor_process.returncode = 0
+
     # Allow another API launch to continue
     if local_lock:
         local_lock.release()


### PR DESCRIPTION
Fixes https://tfs.ansys.com:8443/tfs/ANSYS_development/Portfolio/_workitems/edit/1486161

At garbage collection, the processes are closed in random order. This creates possible race conditions when we do not use atexit() to control the cleanup.
This fix creates the minimum disruption to the way the subprocess to launch a server currently works, making sure we don't break existing integrations. The cleanup is still done correctly. 
A more ideal solution would require changing the way the subprocess is launched (by detaching it and keeping track of the process), but that would risk breaking current integrations.