### PR TITLE
Fix: Check on exec_basis

### DIFF
--- a/.github/workflows/scan_sbom.yml
+++ b/.github/workflows/scan_sbom.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: PyAnsys Vulnerability check (on main)
         if: github.ref == 'refs/heads/main'
-        uses: ansys/actions/check-vulnerabilities@v10.3.2
+        uses: ansys/actions/check-vulnerabilities@v11.0.0
         with:
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
           python-package-name: ${{ env.PACKAGE_NAME }}
@@ -81,7 +81,7 @@ jobs:
 
       - name: PyAnsys Vulnerability check (on dev)
         if: github.ref != 'refs/heads/main'
-        uses: ansys/actions/check-vulnerabilities@v10.3.2
+        uses: ansys/actions/check-vulnerabilities@v11.0.0
         with:
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
           python-package-name: ${{ env.PACKAGE_NAME }}

--- a/.github/workflows/scan_sbom.yml
+++ b/.github/workflows/scan_sbom.yml
@@ -69,6 +69,8 @@ jobs:
       - name: PyAnsys Vulnerability check (on main)
         if: github.ref == 'refs/heads/main'
         uses: ansys/actions/check-vulnerabilities@v10.3.2
+        env:
+          PYTHONSAFEPATH: "1"
         with:
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
           python-package-name: ${{ env.PACKAGE_NAME }}
@@ -80,6 +82,8 @@ jobs:
       - name: PyAnsys Vulnerability check (on dev)
         if: github.ref != 'refs/heads/main'
         uses: ansys/actions/check-vulnerabilities@v10.3.2
+        env:
+          PYTHONSAFEPATH: "1"
         with:
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
           python-package-name: ${{ env.PACKAGE_NAME }}

--- a/.github/workflows/scan_sbom.yml
+++ b/.github/workflows/scan_sbom.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: PyAnsys Vulnerability check (on main)
         if: github.ref == 'refs/heads/main'
-        uses: ansys/actions/check-vulnerabilities@v11.0.0
+        uses: ansys/actions/check-vulnerabilities@v10.3.6
         with:
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
           python-package-name: ${{ env.PACKAGE_NAME }}
@@ -81,7 +81,7 @@ jobs:
 
       - name: PyAnsys Vulnerability check (on dev)
         if: github.ref != 'refs/heads/main'
-        uses: ansys/actions/check-vulnerabilities@v11.0.0
+        uses: ansys/actions/check-vulnerabilities@v10.3.6
         with:
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
           python-package-name: ${{ env.PACKAGE_NAME }}

--- a/.github/workflows/scan_sbom.yml
+++ b/.github/workflows/scan_sbom.yml
@@ -55,6 +55,8 @@ jobs:
   vulnerabilities:
     name: Vulnerabilities
     runs-on: ubuntu-latest
+    env:
+      PYTHONPATH: ${{ github.workspace }}/codegen
 
     steps:
       - name: Checkout repository
@@ -69,8 +71,6 @@ jobs:
       - name: PyAnsys Vulnerability check (on main)
         if: github.ref == 'refs/heads/main'
         uses: ansys/actions/check-vulnerabilities@v10.3.2
-        env:
-          PYTHONSAFEPATH: "1"
         with:
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
           python-package-name: ${{ env.PACKAGE_NAME }}
@@ -82,8 +82,6 @@ jobs:
       - name: PyAnsys Vulnerability check (on dev)
         if: github.ref != 'refs/heads/main'
         uses: ansys/actions/check-vulnerabilities@v10.3.2
-        env:
-          PYTHONSAFEPATH: "1"
         with:
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
           python-package-name: ${{ env.PACKAGE_NAME }}

--- a/src/ansys/dynamicreporting/core/utils/report_remote_server.py
+++ b/src/ansys/dynamicreporting/core/utils/report_remote_server.py
@@ -1379,8 +1379,20 @@ def create_new_local_database(
     exec_basis=None,
     ansys_version=None,
 ):
-    """Create a new, empty sqlite database  If parent is not None, a QtGui will be
-    used."""
+    """
+    Create a new, empty sqlite database  If parent is not None, a QtGui will be
+    used.
+
+    :param parent:  If using Qt, this is the parent to all Qt dialogs.  In non-Qt cases, None should be passed.
+    :param str directory: The database directory to create.
+    :param dict return_info: If set to a dictionary, will return the 'directory' of the created database.
+    :param bool run_local: If True, create the database directly in-process by running Django migrations and seeding the default user/group. If False, invoke ``nexus_utility create_new_database`` in a separate process.
+    :param bool raise_exception: If True, the function will raise exceptions on errors instead of returning False
+    :param str exec_basis: path to the ADR installation to use.
+    :param ansys_version int: version corresponding to the installation.
+
+    :return bool: True on success and False on failure.
+    """
     if parent and _load_qt():  # pragma: no cover
         title = "Select an empty folder to create the database in"
         fn = QtWidgets.QFileDialog.getExistingDirectory(parent, title, directory)

--- a/src/ansys/dynamicreporting/core/utils/report_remote_server.py
+++ b/src/ansys/dynamicreporting/core/utils/report_remote_server.py
@@ -1439,9 +1439,16 @@ def create_new_local_database(
             if len(secret_key):
                 f.write(secret_key)
             f.close()
-            srcdir = os.path.join(
-                report_utils.enve_home(), "nexus" + report_utils.ceiversion_nexus_suffix(), "django"
-            )
+            if exec_basis:
+                srcdir = os.path.join(
+                    exec_basis, "nexus" + report_utils.ceiversion_nexus_suffix(), "django"
+                )
+            else:
+                srcdir = os.path.join(
+                    report_utils.enve_home(),
+                    "nexus" + report_utils.ceiversion_nexus_suffix(),
+                    "django",
+                )
             # In Python 3, we use the migration command to build the new database file and add the 'nexus'
             # superuser programmatically.  We Also stamp the current csf version into the media directory.
             os.environ["CEI_NEXUS_SECRET_KEY"] = secret_key


### PR DESCRIPTION
Addresses https://ado.internal.synopsys.com/tfs/ANSYS_development/Portfolio/_backlogs/backlog/Nexus/Epics%20(Sagas)/?workitem=1424524

If exec_basis is available, it should be used instead of enve_home. This is particularly important when you are using cpython from CEI since enve_home in that case will return the path inside CEI instead of ADR - and that won't work once CEI removes the django directory.

Looks like this check is implemented in a number of places, but this one was missing.

Adding also some docstring to a class.