### PR TITLE
fix: avoid reprocessing rewritten HTML export paths

### DIFF
--- a/src/ansys/dynamicreporting/core/serverless/html_exporter.py
+++ b/src/ansys/dynamicreporting/core/serverless/html_exporter.py
@@ -209,13 +209,25 @@ class ServerlessReportExporter:
         while True:
             # Find the next match using the legacy priority order
             idx1 = -1
+            matched_pattern = ""
             for pat in patterns:
                 pos = text.find(pat, current)
                 if pos != -1:
                     idx1 = pos
+                    matched_pattern = pat
                     break
             if idx1 == -1:
                 return text  # nothing more to replace
+
+            # The generic ``<script ...>`` pass runs after the dedicated
+            # ``<script src=...>`` pass, so already-rewritten relative paths can
+            # appear here as ``./media/...`` or ``./ansys...``.  Those are
+            # already export-safe and should not be re-processed with the legacy
+            # quote heuristic, which would otherwise truncate them at the next
+            # ``.`` (for example ``./media/jquery.min.js`` -> ``/media/jquery``).
+            if idx1 > 0 and text[idx1 - 1] == ".":
+                current = idx1 + len(matched_pattern)
+                continue
 
             # Legacy heuristic: assume we're inside an attribute quoted by the char before the path
             quote = text[idx1 - 1]

--- a/tests/serverless/test_html_exporter.py
+++ b/tests/serverless/test_html_exporter.py
@@ -22,6 +22,7 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 import textwrap
 from unittest.mock import patch
@@ -353,6 +354,53 @@ def test_missing_source_file_keeps_original_ref(adr_serverless, tmp_path: Path):
     out = (tmp_path / "export9" / "index.html").read_text(encoding="utf-8")
     # Exporter leaves the original path when it can't find a local file
     assert missing_href in out
+
+
+@pytest.mark.ado_test
+def test_script_src_blocks_are_not_reprocessed_after_relative_rewrite(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+):
+    """Skip the generic script pass once a src-only tag is already export-safe."""
+    static_dir = tmp_path / "static-src"
+    media_dir = tmp_path / "media-src"
+    ver = "252"
+    static_url = "/static/"
+    media_url = "/media/"
+
+    _write(static_dir / "website/images/favicon.png", b"P")
+    _write(static_dir / "website/scripts/jquery.min.js", "window.jqueryLoaded = true;")
+    _write(static_dir / f"ansys{ver}/nexus/utils/js-unzip.js", "window.unzipLoaded = true;")
+
+    html = textwrap.dedent(
+        f"""
+        <div>
+          <script src="{static_url}website/scripts/jquery.min.js"></script>
+          <script src="{static_url}ansys{ver}/nexus/utils/js-unzip.js"></script>
+        </div>
+        """
+    )
+
+    logger = logging.getLogger("test_html_exporter_script_rewrite")
+    caplog.set_level(logging.WARNING, logger=logger.name)
+
+    exporter = ServerlessReportExporter(
+        html_content=html,
+        output_dir=tmp_path / "export10",
+        static_dir=static_dir,
+        media_dir=media_dir,
+        static_url=static_url,
+        media_url=media_url,
+        ansys_version=ver,
+        logger=logger,
+    )
+    exporter.export()
+
+    warning_messages = [record.getMessage() for record in caplog.records]
+    assert not any("Unable to find local file for path" in message for message in warning_messages)
+
+    out = (tmp_path / "export10" / "index.html").read_text(encoding="utf-8")
+    assert 'src="./media/jquery.min.js"' in out
+    assert f'src="./ansys{ver}/nexus/utils/js-unzip.js"' in out
 
 
 def test_detect_mathjax_version_4x_from_static_tree(tmp_path: Path):


### PR DESCRIPTION
Resolves https://ado.internal.synopsys.com/tfs/ANSYS_Development/Portfolio/_workitems/edit/1496017

## Summary
- skip already-relative `./media/...` and `./ansys...` paths during the generic script rewrite pass so standalone HTML export stops logging fake missing-file warnings
- add a focused exporter regression test covering script `src` tags after the first rewrite pass

## Test plan
- [x] `uv run pytest tests/serverless/test_html_exporter.py -k reprocessed_after_relative_rewrite`
- [x] replay the saved standalone export input against real media/static directories and confirm the warning list is gone